### PR TITLE
Fixed 'Number of parts with price information' statistic.

### DIFF
--- a/src/Repository/PartRepository.php
+++ b/src/Repository/PartRepository.php
@@ -75,7 +75,7 @@ class PartRepository extends NamedDBElementRepository
     public function getPartsCountWithPrice(): int
     {
         $qb = $this->createQueryBuilder('part');
-        $qb->select('COUNT(part)')
+        $qb->select('COUNT(DISTINCT part)')
             ->innerJoin('part.orderdetails', 'orderdetail')
             ->innerJoin('orderdetail.pricedetails', 'pricedetail')
             ->where('pricedetail.price > 0.0');


### PR DESCRIPTION
Sorry for the mess! This time it should work out. This pull request fixes a tiny issue with the statistic of "Number of parts with price information". 