### PR TITLE
Fix Provider capabilities should be shown in the same order #1166

### DIFF
--- a/src/Services/InfoProviderSystem/Providers/DigikeyProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/DigikeyProvider.php
@@ -88,10 +88,10 @@ class DigikeyProvider implements InfoProviderInterface
     {
         return [
             ProviderCapabilities::BASIC,
-            ProviderCapabilities::FOOTPRINT,
             ProviderCapabilities::PICTURE,
             ProviderCapabilities::DATASHEET,
             ProviderCapabilities::PRICE,
+            ProviderCapabilities::FOOTPRINT,
         ];
     }
 

--- a/src/Services/InfoProviderSystem/Providers/Element14Provider.php
+++ b/src/Services/InfoProviderSystem/Providers/Element14Provider.php
@@ -307,6 +307,7 @@ class Element14Provider implements InfoProviderInterface
             ProviderCapabilities::BASIC,
             ProviderCapabilities::PICTURE,
             ProviderCapabilities::DATASHEET,
+            ProviderCapabilities::PRICE,
         ];
     }
 }

--- a/src/Services/InfoProviderSystem/Providers/OctopartProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/OctopartProvider.php
@@ -399,10 +399,10 @@ class OctopartProvider implements InfoProviderInterface
     {
         return [
             ProviderCapabilities::BASIC,
-            ProviderCapabilities::FOOTPRINT,
             ProviderCapabilities::PICTURE,
             ProviderCapabilities::DATASHEET,
             ProviderCapabilities::PRICE,
+            ProviderCapabilities::FOOTPRINT,
         ];
     }
 }

--- a/src/Services/InfoProviderSystem/Providers/PollinProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/PollinProvider.php
@@ -244,8 +244,8 @@ class PollinProvider implements InfoProviderInterface
         return [
             ProviderCapabilities::BASIC,
             ProviderCapabilities::PICTURE,
+            ProviderCapabilities::DATASHEET,
             ProviderCapabilities::PRICE,
-            ProviderCapabilities::DATASHEET
         ];
     }
 }

--- a/src/Services/InfoProviderSystem/Providers/TMEProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/TMEProvider.php
@@ -290,10 +290,10 @@ class TMEProvider implements InfoProviderInterface
     {
         return [
             ProviderCapabilities::BASIC,
-            ProviderCapabilities::FOOTPRINT,
             ProviderCapabilities::PICTURE,
             ProviderCapabilities::DATASHEET,
             ProviderCapabilities::PRICE,
+            ProviderCapabilities::FOOTPRINT,
         ];
     }
 }


### PR DESCRIPTION
Provide the ProviderCapabilities in the following order:
ProviderCapabilities::BASIC,
ProviderCapabilities::PICTURE,
ProviderCapabilities::DATASHEET,
ProviderCapabilities::PRICE,
ProviderCapabilities::FOOTPRINT,

Footprint seems to be the least common, so put it at the end of the list.