### PR TITLE
added feature of part-id in project bom view

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -4,6 +4,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Config\Loader\ParamConfigurator as Param;
+
 /**
  * This class provides array-shapes for configuring the services and bundles of an application.
  *
@@ -124,1740 +126,1740 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type FrameworkConfig = array{
- *     secret?: scalar|null,
- *     http_method_override?: bool, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
- *     allowed_http_method_override?: list<string>|null,
- *     trust_x_sendfile_type_header?: scalar|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
- *     ide?: scalar|null, // Default: "%env(default::SYMFONY_IDE)%"
- *     test?: bool,
- *     default_locale?: scalar|null, // Default: "en"
- *     set_locale_from_accept_language?: bool, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
- *     set_content_language_from_locale?: bool, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
- *     enabled_locales?: list<scalar|null>,
- *     trusted_hosts?: list<scalar|null>,
+ *     secret?: scalar|null|Param,
+ *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
+ *     allowed_http_method_override?: list<string|Param>|null,
+ *     trust_x_sendfile_type_header?: scalar|null|Param, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|null|Param, // Default: "%env(default::SYMFONY_IDE)%"
+ *     test?: bool|Param,
+ *     default_locale?: scalar|null|Param, // Default: "en"
+ *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
+ *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
+ *     enabled_locales?: list<scalar|null|Param>,
+ *     trusted_hosts?: list<scalar|null|Param>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: list<scalar|null>,
- *     error_controller?: scalar|null, // Default: "error_controller"
- *     handle_all_throwables?: bool, // HttpKernel will handle all kinds of \Throwable. // Default: true
+ *     trusted_headers?: list<scalar|null|Param>,
+ *     error_controller?: scalar|null|Param, // Default: "error_controller"
+ *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
- *         enabled?: scalar|null, // Default: null
- *         stateless_token_ids?: list<scalar|null>,
- *         check_header?: scalar|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
- *         cookie_name?: scalar|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *         enabled?: scalar|null|Param, // Default: null
+ *         stateless_token_ids?: list<scalar|null|Param>,
+ *         check_header?: scalar|null|Param, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|null|Param, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
  *     },
  *     form?: bool|array{ // Form configuration
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *         csrf_protection?: array{
- *             enabled?: scalar|null, // Default: null
- *             token_id?: scalar|null, // Default: null
- *             field_name?: scalar|null, // Default: "_token"
- *             field_attr?: array<string, scalar|null>,
+ *             enabled?: scalar|null|Param, // Default: null
+ *             token_id?: scalar|null|Param, // Default: null
+ *             field_name?: scalar|null|Param, // Default: "_token"
+ *             field_attr?: array<string, scalar|null|Param>,
  *         },
  *     },
  *     http_cache?: bool|array{ // HTTP cache configuration
- *         enabled?: bool, // Default: false
- *         debug?: bool, // Default: "%kernel.debug%"
- *         trace_level?: "none"|"short"|"full",
- *         trace_header?: scalar|null,
- *         default_ttl?: int,
- *         private_headers?: list<scalar|null>,
- *         skip_response_headers?: list<scalar|null>,
- *         allow_reload?: bool,
- *         allow_revalidate?: bool,
- *         stale_while_revalidate?: int,
- *         stale_if_error?: int,
- *         terminate_on_cache_hit?: bool,
+ *         enabled?: bool|Param, // Default: false
+ *         debug?: bool|Param, // Default: "%kernel.debug%"
+ *         trace_level?: "none"|"short"|"full"|Param,
+ *         trace_header?: scalar|null|Param,
+ *         default_ttl?: int|Param,
+ *         private_headers?: list<scalar|null|Param>,
+ *         skip_response_headers?: list<scalar|null|Param>,
+ *         allow_reload?: bool|Param,
+ *         allow_revalidate?: bool|Param,
+ *         stale_while_revalidate?: int|Param,
+ *         stale_if_error?: int|Param,
+ *         terminate_on_cache_hit?: bool|Param,
  *     },
  *     esi?: bool|array{ // ESI configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     ssi?: bool|array{ // SSI configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     fragments?: bool|array{ // Fragments configuration
- *         enabled?: bool, // Default: false
- *         hinclude_default_template?: scalar|null, // Default: null
- *         path?: scalar|null, // Default: "/_fragment"
+ *         enabled?: bool|Param, // Default: false
+ *         hinclude_default_template?: scalar|null|Param, // Default: null
+ *         path?: scalar|null|Param, // Default: "/_fragment"
  *     },
  *     profiler?: bool|array{ // Profiler configuration
- *         enabled?: bool, // Default: false
- *         collect?: bool, // Default: true
- *         collect_parameter?: scalar|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
- *         only_exceptions?: bool, // Default: false
- *         only_main_requests?: bool, // Default: false
- *         dsn?: scalar|null, // Default: "file:%kernel.cache_dir%/profiler"
- *         collect_serializer_data?: bool, // Enables the serializer data collector and profiler panel. // Default: false
+ *         enabled?: bool|Param, // Default: false
+ *         collect?: bool|Param, // Default: true
+ *         collect_parameter?: scalar|null|Param, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         only_exceptions?: bool|Param, // Default: false
+ *         only_main_requests?: bool|Param, // Default: false
+ *         dsn?: scalar|null|Param, // Default: "file:%kernel.cache_dir%/profiler"
+ *         collect_serializer_data?: bool|Param, // Enables the serializer data collector and profiler panel. // Default: false
  *     },
  *     workflows?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         workflows?: array<string, array{ // Default: []
  *             audit_trail?: bool|array{
- *                 enabled?: bool, // Default: false
+ *                 enabled?: bool|Param, // Default: false
  *             },
- *             type?: "workflow"|"state_machine", // Default: "state_machine"
+ *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
  *             marking_store?: array{
- *                 type?: "method",
- *                 property?: scalar|null,
- *                 service?: scalar|null,
+ *                 type?: "method"|Param,
+ *                 property?: scalar|null|Param,
+ *                 service?: scalar|null|Param,
  *             },
- *             supports?: list<scalar|null>,
- *             definition_validators?: list<scalar|null>,
- *             support_strategy?: scalar|null,
- *             initial_marking?: list<scalar|null>,
- *             events_to_dispatch?: list<string>|null,
+ *             supports?: list<scalar|null|Param>,
+ *             definition_validators?: list<scalar|null|Param>,
+ *             support_strategy?: scalar|null|Param,
+ *             initial_marking?: list<scalar|null|Param>,
+ *             events_to_dispatch?: list<string|Param>|null,
  *             places?: list<array{ // Default: []
- *                 name: scalar|null,
+ *                 name: scalar|null|Param,
  *                 metadata?: list<mixed>,
  *             }>,
  *             transitions: list<array{ // Default: []
- *                 name: string,
- *                 guard?: string, // An expression to block the transition.
+ *                 name: string|Param,
+ *                 guard?: string|Param, // An expression to block the transition.
  *                 from?: list<array{ // Default: []
- *                     place: string,
- *                     weight?: int, // Default: 1
+ *                     place: string|Param,
+ *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 to?: list<array{ // Default: []
- *                     place: string,
- *                     weight?: int, // Default: 1
+ *                     place: string|Param,
+ *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 weight?: int, // Default: 1
+ *                 weight?: int|Param, // Default: 1
  *                 metadata?: list<mixed>,
  *             }>,
  *             metadata?: list<mixed>,
  *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
- *         enabled?: bool, // Default: false
- *         resource: scalar|null,
- *         type?: scalar|null,
- *         cache_dir?: scalar|null, // Deprecated: Setting the "framework.router.cache_dir.cache_dir" configuration option is deprecated. It will be removed in version 8.0. // Default: "%kernel.build_dir%"
- *         default_uri?: scalar|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
- *         http_port?: scalar|null, // Default: 80
- *         https_port?: scalar|null, // Default: 443
- *         strict_requirements?: scalar|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
- *         utf8?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: false
+ *         resource: scalar|null|Param,
+ *         type?: scalar|null|Param,
+ *         cache_dir?: scalar|null|Param, // Deprecated: Setting the "framework.router.cache_dir.cache_dir" configuration option is deprecated. It will be removed in version 8.0. // Default: "%kernel.build_dir%"
+ *         default_uri?: scalar|null|Param, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|null|Param, // Default: 80
+ *         https_port?: scalar|null|Param, // Default: 443
+ *         strict_requirements?: scalar|null|Param, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         utf8?: bool|Param, // Default: true
  *     },
  *     session?: bool|array{ // Session configuration
- *         enabled?: bool, // Default: false
- *         storage_factory_id?: scalar|null, // Default: "session.storage.factory.native"
- *         handler_id?: scalar|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
- *         name?: scalar|null,
- *         cookie_lifetime?: scalar|null,
- *         cookie_path?: scalar|null,
- *         cookie_domain?: scalar|null,
- *         cookie_secure?: true|false|"auto", // Default: "auto"
- *         cookie_httponly?: bool, // Default: true
- *         cookie_samesite?: null|"lax"|"strict"|"none", // Default: "lax"
- *         use_cookies?: bool,
- *         gc_divisor?: scalar|null,
- *         gc_probability?: scalar|null,
- *         gc_maxlifetime?: scalar|null,
- *         save_path?: scalar|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
- *         metadata_update_threshold?: int, // Seconds to wait between 2 session metadata updates. // Default: 0
- *         sid_length?: int, // Deprecated: Setting the "framework.session.sid_length.sid_length" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
- *         sid_bits_per_character?: int, // Deprecated: Setting the "framework.session.sid_bits_per_character.sid_bits_per_character" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
+ *         enabled?: bool|Param, // Default: false
+ *         storage_factory_id?: scalar|null|Param, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|null|Param, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|null|Param,
+ *         cookie_lifetime?: scalar|null|Param,
+ *         cookie_path?: scalar|null|Param,
+ *         cookie_domain?: scalar|null|Param,
+ *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
+ *         cookie_httponly?: bool|Param, // Default: true
+ *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *         use_cookies?: bool|Param,
+ *         gc_divisor?: scalar|null|Param,
+ *         gc_probability?: scalar|null|Param,
+ *         gc_maxlifetime?: scalar|null|Param,
+ *         save_path?: scalar|null|Param, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
+ *         sid_length?: int|Param, // Deprecated: Setting the "framework.session.sid_length.sid_length" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
+ *         sid_bits_per_character?: int|Param, // Deprecated: Setting the "framework.session.sid_bits_per_character.sid_bits_per_character" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
  *     },
  *     request?: bool|array{ // Request configuration
- *         enabled?: bool, // Default: false
- *         formats?: array<string, string|list<scalar|null>>,
+ *         enabled?: bool|Param, // Default: false
+ *         formats?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
- *         enabled?: bool, // Default: true
- *         strict_mode?: bool, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *         version_strategy?: scalar|null, // Default: null
- *         version?: scalar|null, // Default: null
- *         version_format?: scalar|null, // Default: "%%s?%%s"
- *         json_manifest_path?: scalar|null, // Default: null
- *         base_path?: scalar|null, // Default: ""
- *         base_urls?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *         version_strategy?: scalar|null|Param, // Default: null
+ *         version?: scalar|null|Param, // Default: null
+ *         version_format?: scalar|null|Param, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|null|Param, // Default: null
+ *         base_path?: scalar|null|Param, // Default: ""
+ *         base_urls?: list<scalar|null|Param>,
  *         packages?: array<string, array{ // Default: []
- *             strict_mode?: bool, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|null, // Default: null
- *             version?: scalar|null,
- *             version_format?: scalar|null, // Default: null
- *             json_manifest_path?: scalar|null, // Default: null
- *             base_path?: scalar|null, // Default: ""
- *             base_urls?: list<scalar|null>,
+ *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *             version_strategy?: scalar|null|Param, // Default: null
+ *             version?: scalar|null|Param,
+ *             version_format?: scalar|null|Param, // Default: null
+ *             json_manifest_path?: scalar|null|Param, // Default: null
+ *             base_path?: scalar|null|Param, // Default: ""
+ *             base_urls?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
- *         enabled?: bool, // Default: false
- *         paths?: array<string, scalar|null>,
- *         excluded_patterns?: list<scalar|null>,
- *         exclude_dotfiles?: bool, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
- *         server?: bool, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
- *         public_prefix?: scalar|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
- *         missing_import_mode?: "strict"|"warn"|"ignore", // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
- *         extensions?: array<string, scalar|null>,
- *         importmap_path?: scalar|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
- *         importmap_polyfill?: scalar|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
- *         importmap_script_attributes?: array<string, scalar|null>,
- *         vendor_dir?: scalar|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         enabled?: bool|Param, // Default: false
+ *         paths?: array<string, scalar|null|Param>,
+ *         excluded_patterns?: list<scalar|null|Param>,
+ *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
+ *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
+ *         public_prefix?: scalar|null|Param, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
+ *         extensions?: array<string, scalar|null|Param>,
+ *         importmap_path?: scalar|null|Param, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|null|Param, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|null|Param>,
+ *         vendor_dir?: scalar|null|Param, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
  *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
- *             enabled?: bool, // Default: false
- *             formats?: list<scalar|null>,
- *             extensions?: list<scalar|null>,
+ *             enabled?: bool|Param, // Default: false
+ *             formats?: list<scalar|null|Param>,
+ *             extensions?: list<scalar|null|Param>,
  *         },
  *     },
  *     translator?: bool|array{ // Translator configuration
- *         enabled?: bool, // Default: true
- *         fallbacks?: list<scalar|null>,
- *         logging?: bool, // Default: false
- *         formatter?: scalar|null, // Default: "translator.formatter.default"
- *         cache_dir?: scalar|null, // Default: "%kernel.cache_dir%/translations"
- *         default_path?: scalar|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
- *         paths?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         fallbacks?: list<scalar|null|Param>,
+ *         logging?: bool|Param, // Default: false
+ *         formatter?: scalar|null|Param, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|null|Param, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|null|Param, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|null|Param>,
  *         pseudo_localization?: bool|array{
- *             enabled?: bool, // Default: false
- *             accents?: bool, // Default: true
- *             expansion_factor?: float, // Default: 1.0
- *             brackets?: bool, // Default: true
- *             parse_html?: bool, // Default: false
- *             localizable_html_attributes?: list<scalar|null>,
+ *             enabled?: bool|Param, // Default: false
+ *             accents?: bool|Param, // Default: true
+ *             expansion_factor?: float|Param, // Default: 1.0
+ *             brackets?: bool|Param, // Default: true
+ *             parse_html?: bool|Param, // Default: false
+ *             localizable_html_attributes?: list<scalar|null|Param>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|null,
- *             domains?: list<scalar|null>,
- *             locales?: list<scalar|null>,
+ *             dsn?: scalar|null|Param,
+ *             domains?: list<scalar|null|Param>,
+ *             locales?: list<scalar|null|Param>,
  *         }>,
  *         globals?: array<string, string|array{ // Default: []
  *             value?: mixed,
- *             message?: string,
- *             parameters?: array<string, scalar|null>,
- *             domain?: string,
+ *             message?: string|Param,
+ *             parameters?: array<string, scalar|null|Param>,
+ *             domain?: string|Param,
  *         }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
- *         enabled?: bool, // Default: true
- *         cache?: scalar|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
- *         enable_attributes?: bool, // Default: true
- *         static_method?: list<scalar|null>,
- *         translation_domain?: scalar|null, // Default: "validators"
- *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose", // Default: "html5"
+ *         enabled?: bool|Param, // Default: true
+ *         cache?: scalar|null|Param, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
+ *         enable_attributes?: bool|Param, // Default: true
+ *         static_method?: list<scalar|null|Param>,
+ *         translation_domain?: scalar|null|Param, // Default: "validators"
+ *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
  *         mapping?: array{
- *             paths?: list<scalar|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
  *         not_compromised_password?: bool|array{
- *             enabled?: bool, // When disabled, compromised passwords will be accepted as valid. // Default: true
- *             endpoint?: scalar|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
+ *             endpoint?: scalar|null|Param, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
- *         disable_translation?: bool, // Default: false
+ *         disable_translation?: bool|Param, // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|null>,
+ *             services?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     annotations?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     serializer?: bool|array{ // Serializer configuration
- *         enabled?: bool, // Default: true
- *         enable_attributes?: bool, // Default: true
- *         name_converter?: scalar|null,
- *         circular_reference_handler?: scalar|null,
- *         max_depth_handler?: scalar|null,
+ *         enabled?: bool|Param, // Default: true
+ *         enable_attributes?: bool|Param, // Default: true
+ *         name_converter?: scalar|null|Param,
+ *         circular_reference_handler?: scalar|null|Param,
+ *         max_depth_handler?: scalar|null|Param,
  *         mapping?: array{
- *             paths?: list<scalar|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
  *         default_context?: list<mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|null,
+ *             name_converter?: scalar|null|Param,
  *             default_context?: list<mixed>,
- *             include_built_in_normalizers?: bool, // Whether to include the built-in normalizers // Default: true
- *             include_built_in_encoders?: bool, // Whether to include the built-in encoders // Default: true
+ *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
+ *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
  *         }>,
  *     },
  *     property_access?: bool|array{ // Property access configuration
- *         enabled?: bool, // Default: true
- *         magic_call?: bool, // Default: false
- *         magic_get?: bool, // Default: true
- *         magic_set?: bool, // Default: true
- *         throw_exception_on_invalid_index?: bool, // Default: false
- *         throw_exception_on_invalid_property_path?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
+ *         magic_call?: bool|Param, // Default: false
+ *         magic_get?: bool|Param, // Default: true
+ *         magic_set?: bool|Param, // Default: true
+ *         throw_exception_on_invalid_index?: bool|Param, // Default: false
+ *         throw_exception_on_invalid_property_path?: bool|Param, // Default: true
  *     },
  *     type_info?: bool|array{ // Type info configuration
- *         enabled?: bool, // Default: true
- *         aliases?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         aliases?: array<string, scalar|null|Param>,
  *     },
  *     property_info?: bool|array{ // Property info configuration
- *         enabled?: bool, // Default: true
- *         with_constructor_extractor?: bool, // Registers the constructor extractor.
+ *         enabled?: bool|Param, // Default: true
+ *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor.
  *     },
  *     cache?: array{ // Cache configuration
- *         prefix_seed?: scalar|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
- *         app?: scalar|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
- *         system?: scalar|null, // System related cache pools configuration. // Default: "cache.adapter.system"
- *         directory?: scalar|null, // Default: "%kernel.share_dir%/pools/app"
- *         default_psr6_provider?: scalar|null,
- *         default_redis_provider?: scalar|null, // Default: "redis://localhost"
- *         default_valkey_provider?: scalar|null, // Default: "valkey://localhost"
- *         default_memcached_provider?: scalar|null, // Default: "memcached://localhost"
- *         default_doctrine_dbal_provider?: scalar|null, // Default: "database_connection"
- *         default_pdo_provider?: scalar|null, // Default: null
+ *         prefix_seed?: scalar|null|Param, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|null|Param, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|null|Param, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|null|Param, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|null|Param,
+ *         default_redis_provider?: scalar|null|Param, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|null|Param, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|null|Param, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|null|Param, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|null|Param, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: list<scalar|null>,
- *             tags?: scalar|null, // Default: null
- *             public?: bool, // Default: false
- *             default_lifetime?: scalar|null, // Default lifetime of the pool.
- *             provider?: scalar|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|null,
- *             clearer?: scalar|null,
+ *             adapters?: list<scalar|null|Param>,
+ *             tags?: scalar|null|Param, // Default: null
+ *             public?: bool|Param, // Default: false
+ *             default_lifetime?: scalar|null|Param, // Default lifetime of the pool.
+ *             provider?: scalar|null|Param, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|null|Param,
+ *             clearer?: scalar|null|Param,
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
  *         log?: mixed, // Use the application logger instead of the PHP logger for logging PHP errors. // Default: true
- *         throw?: bool, // Throw PHP errors as \ErrorException instances. // Default: true
+ *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         log_level?: scalar|null|Param, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|null|Param, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|null|Param, // The channel of log message. Null to let Symfony decide. // Default: null
  *     }>,
  *     web_link?: bool|array{ // Web links configuration
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     lock?: bool|string|array{ // Lock configuration
- *         enabled?: bool, // Default: false
- *         resources?: array<string, string|list<scalar|null>>,
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
- *         enabled?: bool, // Default: false
- *         resources?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: array<string, scalar|null|Param>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         routing?: array<string, array{ // Default: []
- *             senders?: list<scalar|null>,
+ *             senders?: list<scalar|null|Param>,
  *         }>,
  *         serializer?: array{
- *             default_serializer?: scalar|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             default_serializer?: scalar|null|Param, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
- *                 format?: scalar|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 format?: scalar|null|Param, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
  *                 context?: array<string, mixed>,
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|null,
- *             serializer?: scalar|null, // Service id of a custom serializer to use. // Default: null
+ *             dsn?: scalar|null|Param,
+ *             serializer?: scalar|null|Param, // Service id of a custom serializer to use. // Default: null
  *             options?: list<mixed>,
- *             failure_transport?: scalar|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *             retry_strategy?: string|array{
- *                 service?: scalar|null, // Service id to override the retry strategy entirely. // Default: null
- *                 max_retries?: int, // Default: 3
- *                 delay?: int, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
- *                 max_delay?: int, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
+ *                 service?: scalar|null|Param, // Service id to override the retry strategy entirely. // Default: null
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
  *             },
- *             rate_limiter?: scalar|null, // Rate limiter name to use when processing messages. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
- *         failure_transport?: scalar|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: list<scalar|null>,
- *         default_bus?: scalar|null, // Default: null
+ *         failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: list<scalar|null|Param>,
+ *         default_bus?: scalar|null|Param, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
- *                 enabled?: bool, // Default: true
- *                 allow_no_handlers?: bool, // Default: false
- *                 allow_no_senders?: bool, // Default: true
+ *                 enabled?: bool|Param, // Default: true
+ *                 allow_no_handlers?: bool|Param, // Default: false
+ *                 allow_no_senders?: bool|Param, // Default: true
  *             },
  *             middleware?: list<string|array{ // Default: []
- *                 id: scalar|null,
+ *                 id: scalar|null|Param,
  *                 arguments?: list<mixed>,
  *             }>,
  *         }>,
  *     },
  *     scheduler?: bool|array{ // Scheduler configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
- *     disallow_search_engine_index?: bool, // Enabled by default when debug is enabled. // Default: true
+ *     disallow_search_engine_index?: bool|Param, // Enabled by default when debug is enabled. // Default: true
  *     http_client?: bool|array{ // HTTP Client configuration
- *         enabled?: bool, // Default: true
- *         max_host_connections?: int, // The maximum number of connections to a single host.
+ *         enabled?: bool|Param, // Default: true
+ *         max_host_connections?: int|Param, // The maximum number of connections to a single host.
  *         default_options?: array{
  *             headers?: array<string, mixed>,
  *             vars?: array<string, mixed>,
- *             max_redirects?: int, // The maximum number of redirects to follow.
- *             http_version?: scalar|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|null>,
- *             proxy?: scalar|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|null, // A comma separated list of hosts that do not require a proxy to be reached.
- *             timeout?: float, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
- *             max_duration?: float, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
- *             verify_peer?: bool, // Indicates if the peer should be verified in a TLS context.
- *             verify_host?: bool, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|null, // A certificate authority file.
- *             capath?: scalar|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|null, // A private key file.
- *             passphrase?: scalar|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
- *                 enabled?: bool, // Default: false
- *                 cache_pool?: string, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
- *                 shared?: bool, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
  *             },
  *             retry_failed?: bool|array{
- *                 enabled?: bool, // Default: false
- *                 retry_strategy?: scalar|null, // service id to override the retry strategy. // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
  *                 http_codes?: array<string, array{ // Default: []
- *                     code?: int,
- *                     methods?: list<string>,
+ *                     code?: int|Param,
+ *                     methods?: list<string|Param>,
  *                 }>,
- *                 max_retries?: int, // Default: 3
- *                 delay?: int, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
- *                 max_delay?: int, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|null|Param, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|null>,
+ *             scope?: scalar|null|Param, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|null|Param, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|null|Param, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|null|Param, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|null|Param, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|null|Param>,
  *             headers?: array<string, mixed>,
- *             max_redirects?: int, // The maximum number of redirects to follow.
- *             http_version?: scalar|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|null>,
- *             proxy?: scalar|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|null, // A comma separated list of hosts that do not require a proxy to be reached.
- *             timeout?: float, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
- *             max_duration?: float, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
- *             verify_peer?: bool, // Indicates if the peer should be verified in a TLS context.
- *             verify_host?: bool, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|null, // A certificate authority file.
- *             capath?: scalar|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|null, // A private key file.
- *             passphrase?: scalar|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
- *                 enabled?: bool, // Default: false
- *                 cache_pool?: string, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
- *                 shared?: bool, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
  *             },
  *             retry_failed?: bool|array{
- *                 enabled?: bool, // Default: false
- *                 retry_strategy?: scalar|null, // service id to override the retry strategy. // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
  *                 http_codes?: array<string, array{ // Default: []
- *                     code?: int,
- *                     methods?: list<string>,
+ *                     code?: int|Param,
+ *                     methods?: list<string|Param>,
  *                 }>,
- *                 max_retries?: int, // Default: 3
- *                 delay?: int, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
- *                 max_delay?: int, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
- *         enabled?: bool, // Default: true
- *         message_bus?: scalar|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         dsn?: scalar|null, // Default: null
- *         transports?: array<string, scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|null|Param, // Default: null
+ *         transports?: array<string, scalar|null|Param>,
  *         envelope?: array{ // Mailer Envelope configuration
- *             sender?: scalar|null,
- *             recipients?: list<scalar|null>,
- *             allowed_recipients?: list<scalar|null>,
+ *             sender?: scalar|null|Param,
+ *             recipients?: list<scalar|null|Param>,
+ *             allowed_recipients?: list<scalar|null|Param>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
- *             enabled?: bool, // Default: false
- *             key?: scalar|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
- *             domain?: scalar|null, // Default: ""
- *             select?: scalar|null, // Default: ""
- *             passphrase?: scalar|null, // The private key passphrase // Default: ""
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|null|Param, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|null|Param, // Default: ""
+ *             select?: scalar|null|Param, // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: ""
  *             options?: array<string, mixed>,
  *         },
  *         smime_signer?: bool|array{ // S/MIME signer configuration
- *             enabled?: bool, // Default: false
- *             key?: scalar|null, // Path to key (in PEM format) // Default: ""
- *             certificate?: scalar|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
- *             passphrase?: scalar|null, // The private key passphrase // Default: null
- *             extra_certificates?: scalar|null, // Default: null
- *             sign_options?: int, // Default: null
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|null|Param, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|null|Param, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|null|Param, // Default: null
+ *             sign_options?: int|Param, // Default: null
  *         },
  *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
- *             enabled?: bool, // Default: false
- *             repository?: scalar|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
- *             cipher?: int, // A set of algorithms used to encrypt the message // Default: null
+ *             enabled?: bool|Param, // Default: false
+ *             repository?: scalar|null|Param, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
  *         },
  *     },
  *     secrets?: bool|array{
- *         enabled?: bool, // Default: true
- *         vault_directory?: scalar|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
- *         local_dotenv_file?: scalar|null, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
- *         decryption_env_var?: scalar|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *         enabled?: bool|Param, // Default: true
+ *         vault_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|null|Param, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
+ *         decryption_env_var?: scalar|null|Param, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
  *     },
  *     notifier?: bool|array{ // Notifier configuration
- *         enabled?: bool, // Default: false
- *         message_bus?: scalar|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         chatter_transports?: array<string, scalar|null>,
- *         texter_transports?: array<string, scalar|null>,
- *         notification_on_failed_messages?: bool, // Default: false
- *         channel_policy?: array<string, string|list<scalar|null>>,
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|null|Param>,
+ *         texter_transports?: array<string, scalar|null|Param>,
+ *         notification_on_failed_messages?: bool|Param, // Default: false
+ *         channel_policy?: array<string, string|list<scalar|null|Param>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|null,
- *             phone?: scalar|null, // Default: ""
+ *             email?: scalar|null|Param,
+ *             phone?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit", // The algorithm to be used by this limiter.
- *             limiters?: list<scalar|null>,
- *             limit?: int, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|null|Param, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|null|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: list<scalar|null|Param>,
+ *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
+ *             interval?: scalar|null|Param, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
- *                 amount?: int, // Amount of tokens to add each interval. // Default: 1
+ *                 interval?: scalar|null|Param, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
- *         enabled?: bool, // Default: true
- *         default_uuid_version?: 7|6|4|1, // Default: 7
- *         name_based_uuid_version?: 5|3, // Default: 5
- *         name_based_uuid_namespace?: scalar|null,
- *         time_based_uuid_version?: 7|6|1, // Default: 7
- *         time_based_uuid_node?: scalar|null,
+ *         enabled?: bool|Param, // Default: true
+ *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
+ *         name_based_uuid_version?: 5|3|Param, // Default: 5
+ *         name_based_uuid_namespace?: scalar|null|Param,
+ *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
+ *         time_based_uuid_node?: scalar|null|Param,
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         sanitizers?: array<string, array{ // Default: []
- *             allow_safe_elements?: bool, // Allows "safe" elements and attributes. // Default: false
- *             allow_static_elements?: bool, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
+ *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
+ *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: list<string>,
- *             drop_elements?: list<string>,
+ *             block_elements?: list<string|Param>,
+ *             drop_elements?: list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
- *             force_attributes?: array<string, array<string, string>>,
- *             force_https_urls?: bool, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: list<string>,
- *             allowed_link_hosts?: list<string>|null,
- *             allow_relative_links?: bool, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: list<string>,
- *             allowed_media_hosts?: list<string>|null,
- *             allow_relative_medias?: bool, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: list<string>,
- *             without_attribute_sanitizers?: list<string>,
- *             max_input_length?: int, // The maximum length allowed for the sanitized input. // Default: 0
+ *             force_attributes?: array<string, array<string, string|Param>>,
+ *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
+ *             allowed_link_schemes?: list<string|Param>,
+ *             allowed_link_hosts?: list<string|Param>|null,
+ *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
+ *             allowed_media_schemes?: list<string|Param>,
+ *             allowed_media_hosts?: list<string|Param>|null,
+ *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
+ *             with_attribute_sanitizers?: list<string|Param>,
+ *             without_attribute_sanitizers?: list<string|Param>,
+ *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
  *     webhook?: bool|array{ // Webhook configuration
- *         enabled?: bool, // Default: false
- *         message_bus?: scalar|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|null|Param, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service: scalar|null,
- *             secret?: scalar|null, // Default: ""
+ *             service: scalar|null|Param,
+ *             secret?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     json_streamer?: bool|array{ // JSON streamer configuration
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  * }
  * @psalm-type DoctrineConfig = array{
  *     dbal?: array{
- *         default_connection?: scalar|null,
+ *         default_connection?: scalar|null|Param,
  *         types?: array<string, string|array{ // Default: []
- *             class: scalar|null,
- *             commented?: bool, // Deprecated: The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.
+ *             class: scalar|null|Param,
+ *             commented?: bool|Param, // Deprecated: The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.
  *         }>,
- *         driver_schemes?: array<string, scalar|null>,
+ *         driver_schemes?: array<string, scalar|null|Param>,
  *         connections?: array<string, array{ // Default: []
- *             url?: scalar|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *             dbname?: scalar|null,
- *             host?: scalar|null, // Defaults to "localhost" at runtime.
- *             port?: scalar|null, // Defaults to null at runtime.
- *             user?: scalar|null, // Defaults to "root" at runtime.
- *             password?: scalar|null, // Defaults to null at runtime.
- *             override_url?: bool, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *             dbname_suffix?: scalar|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *             application_name?: scalar|null,
- *             charset?: scalar|null,
- *             path?: scalar|null,
- *             memory?: bool,
- *             unix_socket?: scalar|null, // The unix socket to use for MySQL
- *             persistent?: bool, // True to use as persistent connection for the ibm_db2 driver
- *             protocol?: scalar|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *             service?: bool, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *             servicename?: scalar|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *             sessionMode?: scalar|null, // The session mode to use for the oci8 driver
- *             server?: scalar|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *             sslmode?: scalar|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *             sslrootcert?: scalar|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *             sslcert?: scalar|null, // The path to the SSL client certificate file for PostgreSQL.
- *             sslkey?: scalar|null, // The path to the SSL client key file for PostgreSQL.
- *             sslcrl?: scalar|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *             pooled?: bool, // True to use a pooled server with the oci8/pdo_oracle driver
- *             MultipleActiveResultSets?: bool, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *             use_savepoints?: bool, // Use savepoints for nested transactions
- *             instancename?: scalar|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *             connectstring?: scalar|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             driver?: scalar|null, // Default: "pdo_mysql"
- *             platform_service?: scalar|null, // Deprecated: The "platform_service" configuration key is deprecated since doctrine-bundle 2.9. DBAL 4 will not support setting a custom platform via connection params anymore.
- *             auto_commit?: bool,
- *             schema_filter?: scalar|null,
- *             logging?: bool, // Default: true
- *             profiling?: bool, // Default: true
- *             profiling_collect_backtrace?: bool, // Enables collecting backtraces when profiling is enabled // Default: false
- *             profiling_collect_schema_errors?: bool, // Enables collecting schema errors when profiling is enabled // Default: true
- *             disable_type_comments?: bool,
- *             server_version?: scalar|null,
- *             idle_connection_ttl?: int, // Default: 600
- *             driver_class?: scalar|null,
- *             wrapper_class?: scalar|null,
- *             keep_slave?: bool, // Deprecated: The "keep_slave" configuration key is deprecated since doctrine-bundle 2.2. Use the "keep_replica" configuration key instead.
- *             keep_replica?: bool,
+ *             url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *             dbname?: scalar|null|Param,
+ *             host?: scalar|null|Param, // Defaults to "localhost" at runtime.
+ *             port?: scalar|null|Param, // Defaults to null at runtime.
+ *             user?: scalar|null|Param, // Defaults to "root" at runtime.
+ *             password?: scalar|null|Param, // Defaults to null at runtime.
+ *             override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
+ *             dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *             application_name?: scalar|null|Param,
+ *             charset?: scalar|null|Param,
+ *             path?: scalar|null|Param,
+ *             memory?: bool|Param,
+ *             unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
+ *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *             protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *             servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *             sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
+ *             server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
+ *             default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *             sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *             sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
+ *             sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
+ *             sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *             use_savepoints?: bool|Param, // Use savepoints for nested transactions
+ *             instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *             connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *             driver?: scalar|null|Param, // Default: "pdo_mysql"
+ *             platform_service?: scalar|null|Param, // Deprecated: The "platform_service" configuration key is deprecated since doctrine-bundle 2.9. DBAL 4 will not support setting a custom platform via connection params anymore.
+ *             auto_commit?: bool|Param,
+ *             schema_filter?: scalar|null|Param,
+ *             logging?: bool|Param, // Default: true
+ *             profiling?: bool|Param, // Default: true
+ *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
+ *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
+ *             disable_type_comments?: bool|Param,
+ *             server_version?: scalar|null|Param,
+ *             idle_connection_ttl?: int|Param, // Default: 600
+ *             driver_class?: scalar|null|Param,
+ *             wrapper_class?: scalar|null|Param,
+ *             keep_slave?: bool|Param, // Deprecated: The "keep_slave" configuration key is deprecated since doctrine-bundle 2.2. Use the "keep_replica" configuration key instead.
+ *             keep_replica?: bool|Param,
  *             options?: array<string, mixed>,
- *             mapping_types?: array<string, scalar|null>,
- *             default_table_options?: array<string, scalar|null>,
- *             schema_manager_factory?: scalar|null, // Default: "doctrine.dbal.default_schema_manager_factory"
- *             result_cache?: scalar|null,
+ *             mapping_types?: array<string, scalar|null|Param>,
+ *             default_table_options?: array<string, scalar|null|Param>,
+ *             schema_manager_factory?: scalar|null|Param, // Default: "doctrine.dbal.default_schema_manager_factory"
+ *             result_cache?: scalar|null|Param,
  *             slaves?: array<string, array{ // Default: []
- *                 url?: scalar|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|null,
- *                 host?: scalar|null, // Defaults to "localhost" at runtime.
- *                 port?: scalar|null, // Defaults to null at runtime.
- *                 user?: scalar|null, // Defaults to "root" at runtime.
- *                 password?: scalar|null, // Defaults to null at runtime.
- *                 override_url?: bool, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *                 dbname_suffix?: scalar|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|null,
- *                 charset?: scalar|null,
- *                 path?: scalar|null,
- *                 memory?: bool,
- *                 unix_socket?: scalar|null, // The unix socket to use for MySQL
- *                 persistent?: bool, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *                 service?: bool, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|null, // The session mode to use for the oci8 driver
- *                 server?: scalar|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|null, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|null, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *                 pooled?: bool, // True to use a pooled server with the oci8/pdo_oracle driver
- *                 MultipleActiveResultSets?: bool, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 use_savepoints?: bool, // Use savepoints for nested transactions
- *                 instancename?: scalar|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                 dbname?: scalar|null|Param,
+ *                 host?: scalar|null|Param, // Defaults to "localhost" at runtime.
+ *                 port?: scalar|null|Param, // Defaults to null at runtime.
+ *                 user?: scalar|null|Param, // Defaults to "root" at runtime.
+ *                 password?: scalar|null|Param, // Defaults to null at runtime.
+ *                 override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
+ *                 dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                 application_name?: scalar|null|Param,
+ *                 charset?: scalar|null|Param,
+ *                 path?: scalar|null|Param,
+ *                 memory?: bool|Param,
+ *                 unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
+ *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                 protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                 servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                 sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
+ *                 server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
+ *                 default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                 sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                 sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
+ *                 sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
+ *                 sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                 use_savepoints?: bool|Param, // Use savepoints for nested transactions
+ *                 instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                 connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
  *             }>,
  *             replicas?: array<string, array{ // Default: []
- *                 url?: scalar|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|null,
- *                 host?: scalar|null, // Defaults to "localhost" at runtime.
- *                 port?: scalar|null, // Defaults to null at runtime.
- *                 user?: scalar|null, // Defaults to "root" at runtime.
- *                 password?: scalar|null, // Defaults to null at runtime.
- *                 override_url?: bool, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *                 dbname_suffix?: scalar|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|null,
- *                 charset?: scalar|null,
- *                 path?: scalar|null,
- *                 memory?: bool,
- *                 unix_socket?: scalar|null, // The unix socket to use for MySQL
- *                 persistent?: bool, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *                 service?: bool, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|null, // The session mode to use for the oci8 driver
- *                 server?: scalar|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|null, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|null, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *                 pooled?: bool, // True to use a pooled server with the oci8/pdo_oracle driver
- *                 MultipleActiveResultSets?: bool, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 use_savepoints?: bool, // Use savepoints for nested transactions
- *                 instancename?: scalar|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                 dbname?: scalar|null|Param,
+ *                 host?: scalar|null|Param, // Defaults to "localhost" at runtime.
+ *                 port?: scalar|null|Param, // Defaults to null at runtime.
+ *                 user?: scalar|null|Param, // Defaults to "root" at runtime.
+ *                 password?: scalar|null|Param, // Defaults to null at runtime.
+ *                 override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
+ *                 dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                 application_name?: scalar|null|Param,
+ *                 charset?: scalar|null|Param,
+ *                 path?: scalar|null|Param,
+ *                 memory?: bool|Param,
+ *                 unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
+ *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                 protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                 servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                 sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
+ *                 server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
+ *                 default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                 sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                 sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
+ *                 sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
+ *                 sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                 use_savepoints?: bool|Param, // Use savepoints for nested transactions
+ *                 instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                 connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
  *             }>,
  *         }>,
  *     },
  *     orm?: array{
- *         default_entity_manager?: scalar|null,
- *         auto_generate_proxy_classes?: scalar|null, // Auto generate mode possible values are: "NEVER", "ALWAYS", "FILE_NOT_EXISTS", "EVAL", "FILE_NOT_EXISTS_OR_CHANGED", this option is ignored when the "enable_native_lazy_objects" option is true // Default: false
- *         enable_lazy_ghost_objects?: bool, // Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation // Default: true
- *         enable_native_lazy_objects?: bool, // Enables the new native implementation of PHP lazy objects instead of generated proxies // Default: false
- *         proxy_dir?: scalar|null, // Configures the path where generated proxy classes are saved when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true // Default: "%kernel.build_dir%/doctrine/orm/Proxies"
- *         proxy_namespace?: scalar|null, // Defines the root namespace for generated proxy classes when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true // Default: "Proxies"
+ *         default_entity_manager?: scalar|null|Param,
+ *         auto_generate_proxy_classes?: scalar|null|Param, // Auto generate mode possible values are: "NEVER", "ALWAYS", "FILE_NOT_EXISTS", "EVAL", "FILE_NOT_EXISTS_OR_CHANGED", this option is ignored when the "enable_native_lazy_objects" option is true // Default: false
+ *         enable_lazy_ghost_objects?: bool|Param, // Enables the new implementation of proxies based on lazy ghosts instead of using the legacy implementation // Default: true
+ *         enable_native_lazy_objects?: bool|Param, // Enables the new native implementation of PHP lazy objects instead of generated proxies // Default: false
+ *         proxy_dir?: scalar|null|Param, // Configures the path where generated proxy classes are saved when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true // Default: "%kernel.build_dir%/doctrine/orm/Proxies"
+ *         proxy_namespace?: scalar|null|Param, // Defines the root namespace for generated proxy classes when using non-native lazy objects, this option is ignored when the "enable_native_lazy_objects" option is true // Default: "Proxies"
  *         controller_resolver?: bool|array{
- *             enabled?: bool, // Default: true
- *             auto_mapping?: bool|null, // Set to false to disable using route placeholders as lookup criteria when the primary key doesn't match the argument name // Default: null
- *             evict_cache?: bool, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
+ *             enabled?: bool|Param, // Default: true
+ *             auto_mapping?: bool|null|Param, // Set to false to disable using route placeholders as lookup criteria when the primary key doesn't match the argument name // Default: null
+ *             evict_cache?: bool|Param, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
  *         },
  *         entity_managers?: array<string, array{ // Default: []
  *             query_cache_driver?: string|array{
- *                 type?: scalar|null, // Default: null
- *                 id?: scalar|null,
- *                 pool?: scalar|null,
+ *                 type?: scalar|null|Param, // Default: null
+ *                 id?: scalar|null|Param,
+ *                 pool?: scalar|null|Param,
  *             },
  *             metadata_cache_driver?: string|array{
- *                 type?: scalar|null, // Default: null
- *                 id?: scalar|null,
- *                 pool?: scalar|null,
+ *                 type?: scalar|null|Param, // Default: null
+ *                 id?: scalar|null|Param,
+ *                 pool?: scalar|null|Param,
  *             },
  *             result_cache_driver?: string|array{
- *                 type?: scalar|null, // Default: null
- *                 id?: scalar|null,
- *                 pool?: scalar|null,
+ *                 type?: scalar|null|Param, // Default: null
+ *                 id?: scalar|null|Param,
+ *                 pool?: scalar|null|Param,
  *             },
  *             entity_listeners?: array{
  *                 entities?: array<string, array{ // Default: []
  *                     listeners?: array<string, array{ // Default: []
  *                         events?: list<array{ // Default: []
- *                             type?: scalar|null,
- *                             method?: scalar|null, // Default: null
+ *                             type?: scalar|null|Param,
+ *                             method?: scalar|null|Param, // Default: null
  *                         }>,
  *                     }>,
  *                 }>,
  *             },
- *             connection?: scalar|null,
- *             class_metadata_factory_name?: scalar|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
- *             default_repository_class?: scalar|null, // Default: "Doctrine\\ORM\\EntityRepository"
- *             auto_mapping?: scalar|null, // Default: false
- *             naming_strategy?: scalar|null, // Default: "doctrine.orm.naming_strategy.default"
- *             quote_strategy?: scalar|null, // Default: "doctrine.orm.quote_strategy.default"
- *             typed_field_mapper?: scalar|null, // Default: "doctrine.orm.typed_field_mapper.default"
- *             entity_listener_resolver?: scalar|null, // Default: null
- *             fetch_mode_subselect_batch_size?: scalar|null,
- *             repository_factory?: scalar|null, // Default: "doctrine.orm.container_repository_factory"
- *             schema_ignore_classes?: list<scalar|null>,
- *             report_fields_where_declared?: bool, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455. // Default: true
- *             validate_xml_mapping?: bool, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728. // Default: false
+ *             connection?: scalar|null|Param,
+ *             class_metadata_factory_name?: scalar|null|Param, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *             default_repository_class?: scalar|null|Param, // Default: "Doctrine\\ORM\\EntityRepository"
+ *             auto_mapping?: scalar|null|Param, // Default: false
+ *             naming_strategy?: scalar|null|Param, // Default: "doctrine.orm.naming_strategy.default"
+ *             quote_strategy?: scalar|null|Param, // Default: "doctrine.orm.quote_strategy.default"
+ *             typed_field_mapper?: scalar|null|Param, // Default: "doctrine.orm.typed_field_mapper.default"
+ *             entity_listener_resolver?: scalar|null|Param, // Default: null
+ *             fetch_mode_subselect_batch_size?: scalar|null|Param,
+ *             repository_factory?: scalar|null|Param, // Default: "doctrine.orm.container_repository_factory"
+ *             schema_ignore_classes?: list<scalar|null|Param>,
+ *             report_fields_where_declared?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455. // Default: true
+ *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728. // Default: false
  *             second_level_cache?: array{
  *                 region_cache_driver?: string|array{
- *                     type?: scalar|null, // Default: null
- *                     id?: scalar|null,
- *                     pool?: scalar|null,
+ *                     type?: scalar|null|Param, // Default: null
+ *                     id?: scalar|null|Param,
+ *                     pool?: scalar|null|Param,
  *                 },
- *                 region_lock_lifetime?: scalar|null, // Default: 60
- *                 log_enabled?: bool, // Default: true
- *                 region_lifetime?: scalar|null, // Default: 3600
- *                 enabled?: bool, // Default: true
- *                 factory?: scalar|null,
+ *                 region_lock_lifetime?: scalar|null|Param, // Default: 60
+ *                 log_enabled?: bool|Param, // Default: true
+ *                 region_lifetime?: scalar|null|Param, // Default: 3600
+ *                 enabled?: bool|Param, // Default: true
+ *                 factory?: scalar|null|Param,
  *                 regions?: array<string, array{ // Default: []
  *                     cache_driver?: string|array{
- *                         type?: scalar|null, // Default: null
- *                         id?: scalar|null,
- *                         pool?: scalar|null,
+ *                         type?: scalar|null|Param, // Default: null
+ *                         id?: scalar|null|Param,
+ *                         pool?: scalar|null|Param,
  *                     },
- *                     lock_path?: scalar|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
- *                     lock_lifetime?: scalar|null, // Default: 60
- *                     type?: scalar|null, // Default: "default"
- *                     lifetime?: scalar|null, // Default: 0
- *                     service?: scalar|null,
- *                     name?: scalar|null,
+ *                     lock_path?: scalar|null|Param, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                     lock_lifetime?: scalar|null|Param, // Default: 60
+ *                     type?: scalar|null|Param, // Default: "default"
+ *                     lifetime?: scalar|null|Param, // Default: 0
+ *                     service?: scalar|null|Param,
+ *                     name?: scalar|null|Param,
  *                 }>,
  *                 loggers?: array<string, array{ // Default: []
- *                     name?: scalar|null,
- *                     service?: scalar|null,
+ *                     name?: scalar|null|Param,
+ *                     service?: scalar|null|Param,
  *                 }>,
  *             },
- *             hydrators?: array<string, scalar|null>,
+ *             hydrators?: array<string, scalar|null|Param>,
  *             mappings?: array<string, bool|string|array{ // Default: []
- *                 mapping?: scalar|null, // Default: true
- *                 type?: scalar|null,
- *                 dir?: scalar|null,
- *                 alias?: scalar|null,
- *                 prefix?: scalar|null,
- *                 is_bundle?: bool,
+ *                 mapping?: scalar|null|Param, // Default: true
+ *                 type?: scalar|null|Param,
+ *                 dir?: scalar|null|Param,
+ *                 alias?: scalar|null|Param,
+ *                 prefix?: scalar|null|Param,
+ *                 is_bundle?: bool|Param,
  *             }>,
  *             dql?: array{
- *                 string_functions?: array<string, scalar|null>,
- *                 numeric_functions?: array<string, scalar|null>,
- *                 datetime_functions?: array<string, scalar|null>,
+ *                 string_functions?: array<string, scalar|null|Param>,
+ *                 numeric_functions?: array<string, scalar|null|Param>,
+ *                 datetime_functions?: array<string, scalar|null|Param>,
  *             },
  *             filters?: array<string, string|array{ // Default: []
- *                 class: scalar|null,
- *                 enabled?: bool, // Default: false
+ *                 class: scalar|null|Param,
+ *                 enabled?: bool|Param, // Default: false
  *                 parameters?: array<string, mixed>,
  *             }>,
- *             identity_generation_preferences?: array<string, scalar|null>,
+ *             identity_generation_preferences?: array<string, scalar|null|Param>,
  *         }>,
- *         resolve_target_entities?: array<string, scalar|null>,
+ *         resolve_target_entities?: array<string, scalar|null|Param>,
  *     },
  * }
  * @psalm-type DoctrineMigrationsConfig = array{
- *     enable_service_migrations?: bool, // Whether to enable fetching migrations from the service container. // Default: false
- *     migrations_paths?: array<string, scalar|null>,
- *     services?: array<string, scalar|null>,
- *     factories?: array<string, scalar|null>,
+ *     enable_service_migrations?: bool|Param, // Whether to enable fetching migrations from the service container. // Default: false
+ *     migrations_paths?: array<string, scalar|null|Param>,
+ *     services?: array<string, scalar|null|Param>,
+ *     factories?: array<string, scalar|null|Param>,
  *     storage?: array{ // Storage to use for migration status metadata.
  *         table_storage?: array{ // The default metadata storage, implemented as a table in the database.
- *             table_name?: scalar|null, // Default: null
- *             version_column_name?: scalar|null, // Default: null
- *             version_column_length?: scalar|null, // Default: null
- *             executed_at_column_name?: scalar|null, // Default: null
- *             execution_time_column_name?: scalar|null, // Default: null
+ *             table_name?: scalar|null|Param, // Default: null
+ *             version_column_name?: scalar|null|Param, // Default: null
+ *             version_column_length?: scalar|null|Param, // Default: null
+ *             executed_at_column_name?: scalar|null|Param, // Default: null
+ *             execution_time_column_name?: scalar|null|Param, // Default: null
  *         },
  *     },
- *     migrations?: list<scalar|null>,
- *     connection?: scalar|null, // Connection name to use for the migrations database. // Default: null
- *     em?: scalar|null, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
- *     all_or_nothing?: scalar|null, // Run all migrations in a transaction. // Default: false
- *     check_database_platform?: scalar|null, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
- *     custom_template?: scalar|null, // Custom template path for generated migration classes. // Default: null
- *     organize_migrations?: scalar|null, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
- *     enable_profiler?: bool, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
- *     transactional?: bool, // Whether or not to wrap migrations in a single transaction. // Default: true
+ *     migrations?: list<scalar|null|Param>,
+ *     connection?: scalar|null|Param, // Connection name to use for the migrations database. // Default: null
+ *     em?: scalar|null|Param, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
+ *     all_or_nothing?: scalar|null|Param, // Run all migrations in a transaction. // Default: false
+ *     check_database_platform?: scalar|null|Param, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
+ *     custom_template?: scalar|null|Param, // Custom template path for generated migration classes. // Default: null
+ *     organize_migrations?: scalar|null|Param, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
+ *     enable_profiler?: bool|Param, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
+ *     transactional?: bool|Param, // Whether or not to wrap migrations in a single transaction. // Default: true
  * }
  * @psalm-type SecurityConfig = array{
- *     access_denied_url?: scalar|null, // Default: null
- *     session_fixation_strategy?: "none"|"migrate"|"invalidate", // Default: "migrate"
- *     hide_user_not_found?: bool, // Deprecated: The "hide_user_not_found" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.
- *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All, // Default: "none"
- *     erase_credentials?: bool, // Default: true
+ *     access_denied_url?: scalar|null|Param, // Default: null
+ *     session_fixation_strategy?: "none"|"migrate"|"invalidate"|Param, // Default: "migrate"
+ *     hide_user_not_found?: bool|Param, // Deprecated: The "hide_user_not_found" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.
+ *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All|Param, // Default: "none"
+ *     erase_credentials?: bool|Param, // Default: true
  *     access_decision_manager?: array{
- *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority",
- *         service?: scalar|null,
- *         strategy_service?: scalar|null,
- *         allow_if_all_abstain?: bool, // Default: false
- *         allow_if_equal_granted_denied?: bool, // Default: true
+ *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority"|Param,
+ *         service?: scalar|null|Param,
+ *         strategy_service?: scalar|null|Param,
+ *         allow_if_all_abstain?: bool|Param, // Default: false
+ *         allow_if_equal_granted_denied?: bool|Param, // Default: true
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
- *         algorithm?: scalar|null,
- *         migrate_from?: list<scalar|null>,
- *         hash_algorithm?: scalar|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
- *         key_length?: scalar|null, // Default: 40
- *         ignore_case?: bool, // Default: false
- *         encode_as_base64?: bool, // Default: true
- *         iterations?: scalar|null, // Default: 5000
- *         cost?: int, // Default: null
- *         memory_cost?: scalar|null, // Default: null
- *         time_cost?: scalar|null, // Default: null
- *         id?: scalar|null,
+ *         algorithm?: scalar|null|Param,
+ *         migrate_from?: list<scalar|null|Param>,
+ *         hash_algorithm?: scalar|null|Param, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
+ *         key_length?: scalar|null|Param, // Default: 40
+ *         ignore_case?: bool|Param, // Default: false
+ *         encode_as_base64?: bool|Param, // Default: true
+ *         iterations?: scalar|null|Param, // Default: 5000
+ *         cost?: int|Param, // Default: null
+ *         memory_cost?: scalar|null|Param, // Default: null
+ *         time_cost?: scalar|null|Param, // Default: null
+ *         id?: scalar|null|Param,
  *     }>,
  *     providers?: array<string, array{ // Default: []
- *         id?: scalar|null,
+ *         id?: scalar|null|Param,
  *         chain?: array{
- *             providers?: list<scalar|null>,
+ *             providers?: list<scalar|null|Param>,
  *         },
  *         entity?: array{
- *             class: scalar|null, // The full entity class name of your user class.
- *             property?: scalar|null, // Default: null
- *             manager_name?: scalar|null, // Default: null
+ *             class: scalar|null|Param, // The full entity class name of your user class.
+ *             property?: scalar|null|Param, // Default: null
+ *             manager_name?: scalar|null|Param, // Default: null
  *         },
  *         memory?: array{
  *             users?: array<string, array{ // Default: []
- *                 password?: scalar|null, // Default: null
- *                 roles?: list<scalar|null>,
+ *                 password?: scalar|null|Param, // Default: null
+ *                 roles?: list<scalar|null|Param>,
  *             }>,
  *         },
  *         ldap?: array{
- *             service: scalar|null,
- *             base_dn: scalar|null,
- *             search_dn?: scalar|null, // Default: null
- *             search_password?: scalar|null, // Default: null
- *             extra_fields?: list<scalar|null>,
- *             default_roles?: list<scalar|null>,
- *             role_fetcher?: scalar|null, // Default: null
- *             uid_key?: scalar|null, // Default: "sAMAccountName"
- *             filter?: scalar|null, // Default: "({uid_key}={user_identifier})"
- *             password_attribute?: scalar|null, // Default: null
+ *             service: scalar|null|Param,
+ *             base_dn: scalar|null|Param,
+ *             search_dn?: scalar|null|Param, // Default: null
+ *             search_password?: scalar|null|Param, // Default: null
+ *             extra_fields?: list<scalar|null|Param>,
+ *             default_roles?: list<scalar|null|Param>,
+ *             role_fetcher?: scalar|null|Param, // Default: null
+ *             uid_key?: scalar|null|Param, // Default: "sAMAccountName"
+ *             filter?: scalar|null|Param, // Default: "({uid_key}={user_identifier})"
+ *             password_attribute?: scalar|null|Param, // Default: null
  *         },
  *         saml?: array{
- *             user_class: scalar|null,
- *             default_roles?: list<scalar|null>,
+ *             user_class: scalar|null|Param,
+ *             default_roles?: list<scalar|null|Param>,
  *         },
  *     }>,
  *     firewalls: array<string, array{ // Default: []
- *         pattern?: scalar|null,
- *         host?: scalar|null,
- *         methods?: list<scalar|null>,
- *         security?: bool, // Default: true
- *         user_checker?: scalar|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
- *         request_matcher?: scalar|null,
- *         access_denied_url?: scalar|null,
- *         access_denied_handler?: scalar|null,
- *         entry_point?: scalar|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
- *         provider?: scalar|null,
- *         stateless?: bool, // Default: false
- *         lazy?: bool, // Default: false
- *         context?: scalar|null,
+ *         pattern?: scalar|null|Param,
+ *         host?: scalar|null|Param,
+ *         methods?: list<scalar|null|Param>,
+ *         security?: bool|Param, // Default: true
+ *         user_checker?: scalar|null|Param, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
+ *         request_matcher?: scalar|null|Param,
+ *         access_denied_url?: scalar|null|Param,
+ *         access_denied_handler?: scalar|null|Param,
+ *         entry_point?: scalar|null|Param, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
+ *         provider?: scalar|null|Param,
+ *         stateless?: bool|Param, // Default: false
+ *         lazy?: bool|Param, // Default: false
+ *         context?: scalar|null|Param,
  *         logout?: array{
- *             enable_csrf?: bool|null, // Default: null
- *             csrf_token_id?: scalar|null, // Default: "logout"
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_manager?: scalar|null,
- *             path?: scalar|null, // Default: "/logout"
- *             target?: scalar|null, // Default: "/"
- *             invalidate_session?: bool, // Default: true
- *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts">,
+ *             enable_csrf?: bool|null|Param, // Default: null
+ *             csrf_token_id?: scalar|null|Param, // Default: "logout"
+ *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
+ *             csrf_token_manager?: scalar|null|Param,
+ *             path?: scalar|null|Param, // Default: "/logout"
+ *             target?: scalar|null|Param, // Default: "/"
+ *             invalidate_session?: bool|Param, // Default: true
+ *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
  *             delete_cookies?: array<string, array{ // Default: []
- *                 path?: scalar|null, // Default: null
- *                 domain?: scalar|null, // Default: null
- *                 secure?: scalar|null, // Default: false
- *                 samesite?: scalar|null, // Default: null
- *                 partitioned?: scalar|null, // Default: false
+ *                 path?: scalar|null|Param, // Default: null
+ *                 domain?: scalar|null|Param, // Default: null
+ *                 secure?: scalar|null|Param, // Default: false
+ *                 samesite?: scalar|null|Param, // Default: null
+ *                 partitioned?: scalar|null|Param, // Default: false
  *             }>,
  *         },
  *         switch_user?: array{
- *             provider?: scalar|null,
- *             parameter?: scalar|null, // Default: "_switch_user"
- *             role?: scalar|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
- *             target_route?: scalar|null, // Default: null
+ *             provider?: scalar|null|Param,
+ *             parameter?: scalar|null|Param, // Default: "_switch_user"
+ *             role?: scalar|null|Param, // Default: "ROLE_ALLOWED_TO_SWITCH"
+ *             target_route?: scalar|null|Param, // Default: null
  *         },
- *         required_badges?: list<scalar|null>,
- *         custom_authenticators?: list<scalar|null>,
+ *         required_badges?: list<scalar|null|Param>,
+ *         custom_authenticators?: list<scalar|null|Param>,
  *         login_throttling?: array{
- *             limiter?: scalar|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
- *             max_attempts?: int, // Default: 5
- *             interval?: scalar|null, // Default: "1 minute"
- *             lock_factory?: scalar|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
- *             cache_pool?: string, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
- *             storage_service?: string, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
+ *             limiter?: scalar|null|Param, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
+ *             max_attempts?: int|Param, // Default: 5
+ *             interval?: scalar|null|Param, // Default: "1 minute"
+ *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
+ *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
+ *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
  *         },
  *         two_factor?: array{
- *             check_path?: scalar|null, // Default: "/2fa_check"
- *             post_only?: bool, // Default: true
- *             auth_form_path?: scalar|null, // Default: "/2fa"
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             success_handler?: scalar|null, // Default: null
- *             failure_handler?: scalar|null, // Default: null
- *             authentication_required_handler?: scalar|null, // Default: null
- *             auth_code_parameter_name?: scalar|null, // Default: "_auth_code"
- *             trusted_parameter_name?: scalar|null, // Default: "_trusted"
- *             remember_me_sets_trusted?: scalar|null, // Default: false
- *             multi_factor?: bool, // Default: false
- *             prepare_on_login?: bool, // Default: false
- *             prepare_on_access_denied?: bool, // Default: false
- *             enable_csrf?: scalar|null, // Default: false
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null, // Default: "two_factor"
- *             csrf_header?: scalar|null, // Default: null
- *             csrf_token_manager?: scalar|null, // Default: "scheb_two_factor.csrf_token_manager"
- *             provider?: scalar|null, // Default: null
+ *             check_path?: scalar|null|Param, // Default: "/2fa_check"
+ *             post_only?: bool|Param, // Default: true
+ *             auth_form_path?: scalar|null|Param, // Default: "/2fa"
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|null|Param, // Default: "/"
+ *             success_handler?: scalar|null|Param, // Default: null
+ *             failure_handler?: scalar|null|Param, // Default: null
+ *             authentication_required_handler?: scalar|null|Param, // Default: null
+ *             auth_code_parameter_name?: scalar|null|Param, // Default: "_auth_code"
+ *             trusted_parameter_name?: scalar|null|Param, // Default: "_trusted"
+ *             remember_me_sets_trusted?: scalar|null|Param, // Default: false
+ *             multi_factor?: bool|Param, // Default: false
+ *             prepare_on_login?: bool|Param, // Default: false
+ *             prepare_on_access_denied?: bool|Param, // Default: false
+ *             enable_csrf?: scalar|null|Param, // Default: false
+ *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|null|Param, // Default: "two_factor"
+ *             csrf_header?: scalar|null|Param, // Default: null
+ *             csrf_token_manager?: scalar|null|Param, // Default: "scheb_two_factor.csrf_token_manager"
+ *             provider?: scalar|null|Param, // Default: null
  *         },
  *         webauthn?: array{
- *             user_provider?: scalar|null, // Default: null
- *             options_storage?: scalar|null, // Deprecated: The child node "options_storage" at path "security.firewalls..webauthn.options_storage" is deprecated. Please use the root option "options_storage" instead. // Default: null
- *             success_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultSuccessHandler"
- *             failure_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultFailureHandler"
- *             secured_rp_ids?: array<string, scalar|null>,
+ *             user_provider?: scalar|null|Param, // Default: null
+ *             options_storage?: scalar|null|Param, // Deprecated: The child node "options_storage" at path "security.firewalls..webauthn.options_storage" is deprecated. Please use the root option "options_storage" instead. // Default: null
+ *             success_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultSuccessHandler"
+ *             failure_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultFailureHandler"
+ *             secured_rp_ids?: array<string, scalar|null|Param>,
  *             authentication?: bool|array{
- *                 enabled?: bool, // Default: true
- *                 profile?: scalar|null, // Default: "default"
- *                 options_builder?: scalar|null, // Default: null
+ *                 enabled?: bool|Param, // Default: true
+ *                 profile?: scalar|null|Param, // Default: "default"
+ *                 options_builder?: scalar|null|Param, // Default: null
  *                 routes?: array{
- *                     host?: scalar|null, // Default: null
- *                     options_method?: scalar|null, // Default: "POST"
- *                     options_path?: scalar|null, // Default: "/login/options"
- *                     result_method?: scalar|null, // Default: "POST"
- *                     result_path?: scalar|null, // Default: "/login"
+ *                     host?: scalar|null|Param, // Default: null
+ *                     options_method?: scalar|null|Param, // Default: "POST"
+ *                     options_path?: scalar|null|Param, // Default: "/login/options"
+ *                     result_method?: scalar|null|Param, // Default: "POST"
+ *                     result_path?: scalar|null|Param, // Default: "/login"
  *                 },
- *                 options_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultRequestOptionsHandler"
+ *                 options_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultRequestOptionsHandler"
  *             },
  *             registration?: bool|array{
- *                 enabled?: bool, // Default: false
- *                 profile?: scalar|null, // Default: "default"
- *                 options_builder?: scalar|null, // Default: null
+ *                 enabled?: bool|Param, // Default: false
+ *                 profile?: scalar|null|Param, // Default: "default"
+ *                 options_builder?: scalar|null|Param, // Default: null
  *                 routes?: array{
- *                     host?: scalar|null, // Default: null
- *                     options_method?: scalar|null, // Default: "POST"
- *                     options_path?: scalar|null, // Default: "/register/options"
- *                     result_method?: scalar|null, // Default: "POST"
- *                     result_path?: scalar|null, // Default: "/register"
+ *                     host?: scalar|null|Param, // Default: null
+ *                     options_method?: scalar|null|Param, // Default: "POST"
+ *                     options_path?: scalar|null|Param, // Default: "/register/options"
+ *                     result_method?: scalar|null|Param, // Default: "POST"
+ *                     result_path?: scalar|null|Param, // Default: "/register"
  *                 },
- *                 options_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultCreationOptionsHandler"
+ *                 options_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultCreationOptionsHandler"
  *             },
  *         },
  *         x509?: array{
- *             provider?: scalar|null,
- *             user?: scalar|null, // Default: "SSL_CLIENT_S_DN_Email"
- *             credentials?: scalar|null, // Default: "SSL_CLIENT_S_DN"
- *             user_identifier?: scalar|null, // Default: "emailAddress"
+ *             provider?: scalar|null|Param,
+ *             user?: scalar|null|Param, // Default: "SSL_CLIENT_S_DN_Email"
+ *             credentials?: scalar|null|Param, // Default: "SSL_CLIENT_S_DN"
+ *             user_identifier?: scalar|null|Param, // Default: "emailAddress"
  *         },
  *         remote_user?: array{
- *             provider?: scalar|null,
- *             user?: scalar|null, // Default: "REMOTE_USER"
+ *             provider?: scalar|null|Param,
+ *             user?: scalar|null|Param, // Default: "REMOTE_USER"
  *         },
  *         saml?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null, // Default: "Nbgrp\\OneloginSamlBundle\\Security\\Http\\Authentication\\SamlAuthenticationSuccessHandler"
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             identifier_attribute?: scalar|null, // Default: null
- *             use_attribute_friendly_name?: bool, // Default: false
- *             user_factory?: scalar|null, // Default: null
- *             token_factory?: scalar|null, // Default: null
- *             persist_user?: bool, // Default: false
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
+ *             provider?: scalar|null|Param,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|null|Param, // Default: "Nbgrp\\OneloginSamlBundle\\Security\\Http\\Authentication\\SamlAuthenticationSuccessHandler"
+ *             failure_handler?: scalar|null|Param,
+ *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|null|Param, // Default: "/login"
+ *             identifier_attribute?: scalar|null|Param, // Default: null
+ *             use_attribute_friendly_name?: bool|Param, // Default: false
+ *             user_factory?: scalar|null|Param, // Default: null
+ *             token_factory?: scalar|null|Param, // Default: null
+ *             persist_user?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|null|Param, // Default: "/"
+ *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
  *         },
  *         login_link?: array{
- *             check_route: scalar|null, // Route that will validate the login link - e.g. "app_login_link_verify".
- *             check_post_only?: scalar|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
- *             signature_properties: list<scalar|null>,
- *             lifetime?: int, // The lifetime of the login link in seconds. // Default: 600
- *             max_uses?: int, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
- *             used_link_cache?: scalar|null, // Cache service id used to expired links of max_uses is set.
- *             success_handler?: scalar|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
- *             failure_handler?: scalar|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
- *             provider?: scalar|null, // The user provider to load users from.
- *             secret?: scalar|null, // Default: "%kernel.secret%"
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             login_path?: scalar|null, // Default: "/login"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
+ *             check_route: scalar|null|Param, // Route that will validate the login link - e.g. "app_login_link_verify".
+ *             check_post_only?: scalar|null|Param, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
+ *             signature_properties: list<scalar|null|Param>,
+ *             lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
+ *             max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
+ *             used_link_cache?: scalar|null|Param, // Cache service id used to expired links of max_uses is set.
+ *             success_handler?: scalar|null|Param, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
+ *             failure_handler?: scalar|null|Param, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
+ *             provider?: scalar|null|Param, // The user provider to load users from.
+ *             secret?: scalar|null|Param, // Default: "%kernel.secret%"
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|null|Param, // Default: "/"
+ *             login_path?: scalar|null|Param, // Default: "/login"
+ *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
  *         },
  *         form_login?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_parameter?: scalar|null, // Default: "_username"
- *             password_parameter?: scalar|null, // Default: "_password"
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null, // Default: "authenticate"
- *             enable_csrf?: bool, // Default: false
- *             post_only?: bool, // Default: true
- *             form_only?: bool, // Default: false
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
+ *             provider?: scalar|null|Param,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|null|Param,
+ *             failure_handler?: scalar|null|Param,
+ *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|null|Param, // Default: "/login"
+ *             username_parameter?: scalar|null|Param, // Default: "_username"
+ *             password_parameter?: scalar|null|Param, // Default: "_password"
+ *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|null|Param, // Default: "authenticate"
+ *             enable_csrf?: bool|Param, // Default: false
+ *             post_only?: bool|Param, // Default: true
+ *             form_only?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|null|Param, // Default: "/"
+ *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
  *         },
  *         form_login_ldap?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_parameter?: scalar|null, // Default: "_username"
- *             password_parameter?: scalar|null, // Default: "_password"
- *             csrf_parameter?: scalar|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null, // Default: "authenticate"
- *             enable_csrf?: bool, // Default: false
- *             post_only?: bool, // Default: true
- *             form_only?: bool, // Default: false
- *             always_use_default_target_path?: bool, // Default: false
- *             default_target_path?: scalar|null, // Default: "/"
- *             target_path_parameter?: scalar|null, // Default: "_target_path"
- *             use_referer?: bool, // Default: false
- *             failure_path?: scalar|null, // Default: null
- *             failure_forward?: bool, // Default: false
- *             failure_path_parameter?: scalar|null, // Default: "_failure_path"
- *             service?: scalar|null, // Default: "ldap"
- *             dn_string?: scalar|null, // Default: "{user_identifier}"
- *             query_string?: scalar|null,
- *             search_dn?: scalar|null, // Default: ""
- *             search_password?: scalar|null, // Default: ""
+ *             provider?: scalar|null|Param,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|null|Param,
+ *             failure_handler?: scalar|null|Param,
+ *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|null|Param, // Default: "/login"
+ *             username_parameter?: scalar|null|Param, // Default: "_username"
+ *             password_parameter?: scalar|null|Param, // Default: "_password"
+ *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|null|Param, // Default: "authenticate"
+ *             enable_csrf?: bool|Param, // Default: false
+ *             post_only?: bool|Param, // Default: true
+ *             form_only?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|null|Param, // Default: "/"
+ *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
+ *             service?: scalar|null|Param, // Default: "ldap"
+ *             dn_string?: scalar|null|Param, // Default: "{user_identifier}"
+ *             query_string?: scalar|null|Param,
+ *             search_dn?: scalar|null|Param, // Default: ""
+ *             search_password?: scalar|null|Param, // Default: ""
  *         },
  *         json_login?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_path?: scalar|null, // Default: "username"
- *             password_path?: scalar|null, // Default: "password"
+ *             provider?: scalar|null|Param,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|null|Param,
+ *             failure_handler?: scalar|null|Param,
+ *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|null|Param, // Default: "/login"
+ *             username_path?: scalar|null|Param, // Default: "username"
+ *             password_path?: scalar|null|Param, // Default: "password"
  *         },
  *         json_login_ldap?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             check_path?: scalar|null, // Default: "/login_check"
- *             use_forward?: bool, // Default: false
- *             login_path?: scalar|null, // Default: "/login"
- *             username_path?: scalar|null, // Default: "username"
- *             password_path?: scalar|null, // Default: "password"
- *             service?: scalar|null, // Default: "ldap"
- *             dn_string?: scalar|null, // Default: "{user_identifier}"
- *             query_string?: scalar|null,
- *             search_dn?: scalar|null, // Default: ""
- *             search_password?: scalar|null, // Default: ""
+ *             provider?: scalar|null|Param,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|null|Param,
+ *             failure_handler?: scalar|null|Param,
+ *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|null|Param, // Default: "/login"
+ *             username_path?: scalar|null|Param, // Default: "username"
+ *             password_path?: scalar|null|Param, // Default: "password"
+ *             service?: scalar|null|Param, // Default: "ldap"
+ *             dn_string?: scalar|null|Param, // Default: "{user_identifier}"
+ *             query_string?: scalar|null|Param,
+ *             search_dn?: scalar|null|Param, // Default: ""
+ *             search_password?: scalar|null|Param, // Default: ""
  *         },
  *         access_token?: array{
- *             provider?: scalar|null,
- *             remember_me?: bool, // Default: true
- *             success_handler?: scalar|null,
- *             failure_handler?: scalar|null,
- *             realm?: scalar|null, // Default: null
- *             token_extractors?: list<scalar|null>,
+ *             provider?: scalar|null|Param,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|null|Param,
+ *             failure_handler?: scalar|null|Param,
+ *             realm?: scalar|null|Param, // Default: null
+ *             token_extractors?: list<scalar|null|Param>,
  *             token_handler: string|array{
- *                 id?: scalar|null,
+ *                 id?: scalar|null|Param,
  *                 oidc_user_info?: string|array{
- *                     base_uri: scalar|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
+ *                     base_uri: scalar|null|Param, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
  *                     discovery?: array{ // Enable the OIDC discovery.
  *                         cache?: array{
- *                             id: scalar|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             id: scalar|null|Param, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
  *                     },
- *                     claim?: scalar|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
- *                     client?: scalar|null, // HttpClient service id to use to call the OIDC server.
+ *                     claim?: scalar|null|Param, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
+ *                     client?: scalar|null|Param, // HttpClient service id to use to call the OIDC server.
  *                 },
  *                 oidc?: array{
  *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri: list<scalar|null>,
+ *                         base_uri: list<scalar|null|Param>,
  *                         cache?: array{
- *                             id: scalar|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             id: scalar|null|Param, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
  *                     },
- *                     claim?: scalar|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
- *                     audience: scalar|null, // Audience set in the token, for validation purpose.
- *                     issuers: list<scalar|null>,
+ *                     claim?: scalar|null|Param, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
+ *                     audience: scalar|null|Param, // Audience set in the token, for validation purpose.
+ *                     issuers: list<scalar|null|Param>,
  *                     algorithm?: array<mixed>,
- *                     algorithms: list<scalar|null>,
- *                     key?: scalar|null, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
- *                     keyset?: scalar|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
+ *                     algorithms: list<scalar|null|Param>,
+ *                     key?: scalar|null|Param, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
+ *                     keyset?: scalar|null|Param, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
  *                     encryption?: bool|array{
- *                         enabled?: bool, // Default: false
- *                         enforce?: bool, // When enabled, the token shall be encrypted. // Default: false
- *                         algorithms: list<scalar|null>,
- *                         keyset: scalar|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         enabled?: bool|Param, // Default: false
+ *                         enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                         algorithms: list<scalar|null|Param>,
+ *                         keyset: scalar|null|Param, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
  *                     },
  *                 },
  *                 cas?: array{
- *                     validation_url: scalar|null, // CAS server validation URL
- *                     prefix?: scalar|null, // CAS prefix // Default: "cas"
- *                     http_client?: scalar|null, // HTTP Client service // Default: null
+ *                     validation_url: scalar|null|Param, // CAS server validation URL
+ *                     prefix?: scalar|null|Param, // CAS prefix // Default: "cas"
+ *                     http_client?: scalar|null|Param, // HTTP Client service // Default: null
  *                 },
- *                 oauth2?: scalar|null,
+ *                 oauth2?: scalar|null|Param,
  *             },
  *         },
  *         http_basic?: array{
- *             provider?: scalar|null,
- *             realm?: scalar|null, // Default: "Secured Area"
+ *             provider?: scalar|null|Param,
+ *             realm?: scalar|null|Param, // Default: "Secured Area"
  *         },
  *         http_basic_ldap?: array{
- *             provider?: scalar|null,
- *             realm?: scalar|null, // Default: "Secured Area"
- *             service?: scalar|null, // Default: "ldap"
- *             dn_string?: scalar|null, // Default: "{user_identifier}"
- *             query_string?: scalar|null,
- *             search_dn?: scalar|null, // Default: ""
- *             search_password?: scalar|null, // Default: ""
+ *             provider?: scalar|null|Param,
+ *             realm?: scalar|null|Param, // Default: "Secured Area"
+ *             service?: scalar|null|Param, // Default: "ldap"
+ *             dn_string?: scalar|null|Param, // Default: "{user_identifier}"
+ *             query_string?: scalar|null|Param,
+ *             search_dn?: scalar|null|Param, // Default: ""
+ *             search_password?: scalar|null|Param, // Default: ""
  *         },
  *         remember_me?: array{
- *             secret?: scalar|null, // Default: "%kernel.secret%"
- *             service?: scalar|null,
- *             user_providers?: list<scalar|null>,
- *             catch_exceptions?: bool, // Default: true
- *             signature_properties?: list<scalar|null>,
+ *             secret?: scalar|null|Param, // Default: "%kernel.secret%"
+ *             service?: scalar|null|Param,
+ *             user_providers?: list<scalar|null|Param>,
+ *             catch_exceptions?: bool|Param, // Default: true
+ *             signature_properties?: list<scalar|null|Param>,
  *             token_provider?: string|array{
- *                 service?: scalar|null, // The service ID of a custom remember-me token provider.
+ *                 service?: scalar|null|Param, // The service ID of a custom remember-me token provider.
  *                 doctrine?: bool|array{
- *                     enabled?: bool, // Default: false
- *                     connection?: scalar|null, // Default: null
+ *                     enabled?: bool|Param, // Default: false
+ *                     connection?: scalar|null|Param, // Default: null
  *                 },
  *             },
- *             token_verifier?: scalar|null, // The service ID of a custom rememberme token verifier.
- *             name?: scalar|null, // Default: "REMEMBERME"
- *             lifetime?: int, // Default: 31536000
- *             path?: scalar|null, // Default: "/"
- *             domain?: scalar|null, // Default: null
- *             secure?: true|false|"auto", // Default: null
- *             httponly?: bool, // Default: true
- *             samesite?: null|"lax"|"strict"|"none", // Default: "lax"
- *             always_remember_me?: bool, // Default: false
- *             remember_me_parameter?: scalar|null, // Default: "_remember_me"
+ *             token_verifier?: scalar|null|Param, // The service ID of a custom rememberme token verifier.
+ *             name?: scalar|null|Param, // Default: "REMEMBERME"
+ *             lifetime?: int|Param, // Default: 31536000
+ *             path?: scalar|null|Param, // Default: "/"
+ *             domain?: scalar|null|Param, // Default: null
+ *             secure?: true|false|"auto"|Param, // Default: null
+ *             httponly?: bool|Param, // Default: true
+ *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *             always_remember_me?: bool|Param, // Default: false
+ *             remember_me_parameter?: scalar|null|Param, // Default: "_remember_me"
  *         },
  *     }>,
  *     access_control?: list<array{ // Default: []
- *         request_matcher?: scalar|null, // Default: null
- *         requires_channel?: scalar|null, // Default: null
- *         path?: scalar|null, // Use the urldecoded format. // Default: null
- *         host?: scalar|null, // Default: null
- *         port?: int, // Default: null
- *         ips?: list<scalar|null>,
- *         attributes?: array<string, scalar|null>,
- *         route?: scalar|null, // Default: null
- *         methods?: list<scalar|null>,
- *         allow_if?: scalar|null, // Default: null
- *         roles?: list<scalar|null>,
+ *         request_matcher?: scalar|null|Param, // Default: null
+ *         requires_channel?: scalar|null|Param, // Default: null
+ *         path?: scalar|null|Param, // Use the urldecoded format. // Default: null
+ *         host?: scalar|null|Param, // Default: null
+ *         port?: int|Param, // Default: null
+ *         ips?: list<scalar|null|Param>,
+ *         attributes?: array<string, scalar|null|Param>,
+ *         route?: scalar|null|Param, // Default: null
+ *         methods?: list<scalar|null|Param>,
+ *         allow_if?: scalar|null|Param, // Default: null
+ *         roles?: list<scalar|null|Param>,
  *     }>,
- *     role_hierarchy?: array<string, string|list<scalar|null>>,
+ *     role_hierarchy?: array<string, string|list<scalar|null|Param>>,
  * }
  * @psalm-type TwigConfig = array{
- *     form_themes?: list<scalar|null>,
+ *     form_themes?: list<scalar|null|Param>,
  *     globals?: array<string, array{ // Default: []
- *         id?: scalar|null,
- *         type?: scalar|null,
+ *         id?: scalar|null|Param,
+ *         type?: scalar|null|Param,
  *         value?: mixed,
  *     }>,
- *     autoescape_service?: scalar|null, // Default: null
- *     autoescape_service_method?: scalar|null, // Default: null
- *     base_template_class?: scalar|null, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
- *     cache?: scalar|null, // Default: true
- *     charset?: scalar|null, // Default: "%kernel.charset%"
- *     debug?: bool, // Default: "%kernel.debug%"
- *     strict_variables?: bool, // Default: "%kernel.debug%"
- *     auto_reload?: scalar|null,
- *     optimizations?: int,
- *     default_path?: scalar|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
- *     file_name_pattern?: list<scalar|null>,
+ *     autoescape_service?: scalar|null|Param, // Default: null
+ *     autoescape_service_method?: scalar|null|Param, // Default: null
+ *     base_template_class?: scalar|null|Param, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
+ *     cache?: scalar|null|Param, // Default: true
+ *     charset?: scalar|null|Param, // Default: "%kernel.charset%"
+ *     debug?: bool|Param, // Default: "%kernel.debug%"
+ *     strict_variables?: bool|Param, // Default: "%kernel.debug%"
+ *     auto_reload?: scalar|null|Param,
+ *     optimizations?: int|Param,
+ *     default_path?: scalar|null|Param, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
+ *     file_name_pattern?: list<scalar|null|Param>,
  *     paths?: array<string, mixed>,
  *     date?: array{ // The default format options used by the date filter.
- *         format?: scalar|null, // Default: "F j, Y H:i"
- *         interval_format?: scalar|null, // Default: "%d days"
- *         timezone?: scalar|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
+ *         format?: scalar|null|Param, // Default: "F j, Y H:i"
+ *         interval_format?: scalar|null|Param, // Default: "%d days"
+ *         timezone?: scalar|null|Param, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
  *     },
  *     number_format?: array{ // The default format options for the number_format filter.
- *         decimals?: int, // Default: 0
- *         decimal_point?: scalar|null, // Default: "."
- *         thousands_separator?: scalar|null, // Default: ","
+ *         decimals?: int|Param, // Default: 0
+ *         decimal_point?: scalar|null|Param, // Default: "."
+ *         thousands_separator?: scalar|null|Param, // Default: ","
  *     },
  *     mailer?: array{
- *         html_to_text_converter?: scalar|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
+ *         html_to_text_converter?: scalar|null|Param, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
  *     },
  * }
  * @psalm-type WebProfilerConfig = array{
  *     toolbar?: bool|array{ // Profiler toolbar configuration
- *         enabled?: bool, // Default: false
- *         ajax_replace?: bool, // Replace toolbar on AJAX requests // Default: false
+ *         enabled?: bool|Param, // Default: false
+ *         ajax_replace?: bool|Param, // Replace toolbar on AJAX requests // Default: false
  *     },
- *     intercept_redirects?: bool, // Default: false
- *     excluded_ajax_paths?: scalar|null, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
+ *     intercept_redirects?: bool|Param, // Default: false
+ *     excluded_ajax_paths?: scalar|null|Param, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
  * }
  * @psalm-type MonologConfig = array{
- *     use_microseconds?: scalar|null, // Default: true
- *     channels?: list<scalar|null>,
+ *     use_microseconds?: scalar|null|Param, // Default: true
+ *     channels?: list<scalar|null|Param>,
  *     handlers?: array<string, array{ // Default: []
- *         type: scalar|null,
- *         id?: scalar|null,
- *         enabled?: bool, // Default: true
- *         priority?: scalar|null, // Default: 0
- *         level?: scalar|null, // Default: "DEBUG"
- *         bubble?: bool, // Default: true
- *         interactive_only?: bool, // Default: false
- *         app_name?: scalar|null, // Default: null
- *         fill_extra_context?: bool, // Default: false
- *         include_stacktraces?: bool, // Default: false
+ *         type: scalar|null|Param,
+ *         id?: scalar|null|Param,
+ *         enabled?: bool|Param, // Default: true
+ *         priority?: scalar|null|Param, // Default: 0
+ *         level?: scalar|null|Param, // Default: "DEBUG"
+ *         bubble?: bool|Param, // Default: true
+ *         interactive_only?: bool|Param, // Default: false
+ *         app_name?: scalar|null|Param, // Default: null
+ *         fill_extra_context?: bool|Param, // Default: false
+ *         include_stacktraces?: bool|Param, // Default: false
  *         process_psr_3_messages?: array{
- *             enabled?: bool|null, // Default: null
- *             date_format?: scalar|null,
- *             remove_used_context_fields?: bool,
+ *             enabled?: bool|null|Param, // Default: null
+ *             date_format?: scalar|null|Param,
+ *             remove_used_context_fields?: bool|Param,
  *         },
- *         path?: scalar|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
- *         file_permission?: scalar|null, // Default: null
- *         use_locking?: bool, // Default: false
- *         filename_format?: scalar|null, // Default: "{filename}-{date}"
- *         date_format?: scalar|null, // Default: "Y-m-d"
- *         ident?: scalar|null, // Default: false
- *         logopts?: scalar|null, // Default: 1
- *         facility?: scalar|null, // Default: "user"
- *         max_files?: scalar|null, // Default: 0
- *         action_level?: scalar|null, // Default: "WARNING"
- *         activation_strategy?: scalar|null, // Default: null
- *         stop_buffering?: bool, // Default: true
- *         passthru_level?: scalar|null, // Default: null
- *         excluded_404s?: list<scalar|null>,
+ *         path?: scalar|null|Param, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
+ *         file_permission?: scalar|null|Param, // Default: null
+ *         use_locking?: bool|Param, // Default: false
+ *         filename_format?: scalar|null|Param, // Default: "{filename}-{date}"
+ *         date_format?: scalar|null|Param, // Default: "Y-m-d"
+ *         ident?: scalar|null|Param, // Default: false
+ *         logopts?: scalar|null|Param, // Default: 1
+ *         facility?: scalar|null|Param, // Default: "user"
+ *         max_files?: scalar|null|Param, // Default: 0
+ *         action_level?: scalar|null|Param, // Default: "WARNING"
+ *         activation_strategy?: scalar|null|Param, // Default: null
+ *         stop_buffering?: bool|Param, // Default: true
+ *         passthru_level?: scalar|null|Param, // Default: null
+ *         excluded_404s?: list<scalar|null|Param>,
  *         excluded_http_codes?: list<array{ // Default: []
- *             code?: scalar|null,
- *             urls?: list<scalar|null>,
+ *             code?: scalar|null|Param,
+ *             urls?: list<scalar|null|Param>,
  *         }>,
- *         accepted_levels?: list<scalar|null>,
- *         min_level?: scalar|null, // Default: "DEBUG"
- *         max_level?: scalar|null, // Default: "EMERGENCY"
- *         buffer_size?: scalar|null, // Default: 0
- *         flush_on_overflow?: bool, // Default: false
- *         handler?: scalar|null,
- *         url?: scalar|null,
- *         exchange?: scalar|null,
- *         exchange_name?: scalar|null, // Default: "log"
- *         room?: scalar|null,
- *         message_format?: scalar|null, // Default: "text"
- *         api_version?: scalar|null, // Default: null
- *         channel?: scalar|null, // Default: null
- *         bot_name?: scalar|null, // Default: "Monolog"
- *         use_attachment?: scalar|null, // Default: true
- *         use_short_attachment?: scalar|null, // Default: false
- *         include_extra?: scalar|null, // Default: false
- *         icon_emoji?: scalar|null, // Default: null
- *         webhook_url?: scalar|null,
- *         exclude_fields?: list<scalar|null>,
- *         team?: scalar|null,
- *         notify?: scalar|null, // Default: false
- *         nickname?: scalar|null, // Default: "Monolog"
- *         token?: scalar|null,
- *         region?: scalar|null,
- *         source?: scalar|null,
- *         use_ssl?: bool, // Default: true
+ *         accepted_levels?: list<scalar|null|Param>,
+ *         min_level?: scalar|null|Param, // Default: "DEBUG"
+ *         max_level?: scalar|null|Param, // Default: "EMERGENCY"
+ *         buffer_size?: scalar|null|Param, // Default: 0
+ *         flush_on_overflow?: bool|Param, // Default: false
+ *         handler?: scalar|null|Param,
+ *         url?: scalar|null|Param,
+ *         exchange?: scalar|null|Param,
+ *         exchange_name?: scalar|null|Param, // Default: "log"
+ *         room?: scalar|null|Param,
+ *         message_format?: scalar|null|Param, // Default: "text"
+ *         api_version?: scalar|null|Param, // Default: null
+ *         channel?: scalar|null|Param, // Default: null
+ *         bot_name?: scalar|null|Param, // Default: "Monolog"
+ *         use_attachment?: scalar|null|Param, // Default: true
+ *         use_short_attachment?: scalar|null|Param, // Default: false
+ *         include_extra?: scalar|null|Param, // Default: false
+ *         icon_emoji?: scalar|null|Param, // Default: null
+ *         webhook_url?: scalar|null|Param,
+ *         exclude_fields?: list<scalar|null|Param>,
+ *         team?: scalar|null|Param,
+ *         notify?: scalar|null|Param, // Default: false
+ *         nickname?: scalar|null|Param, // Default: "Monolog"
+ *         token?: scalar|null|Param,
+ *         region?: scalar|null|Param,
+ *         source?: scalar|null|Param,
+ *         use_ssl?: bool|Param, // Default: true
  *         user?: mixed,
- *         title?: scalar|null, // Default: null
- *         host?: scalar|null, // Default: null
- *         port?: scalar|null, // Default: 514
- *         config?: list<scalar|null>,
- *         members?: list<scalar|null>,
- *         connection_string?: scalar|null,
- *         timeout?: scalar|null,
- *         time?: scalar|null, // Default: 60
- *         deduplication_level?: scalar|null, // Default: 400
- *         store?: scalar|null, // Default: null
- *         connection_timeout?: scalar|null,
- *         persistent?: bool,
- *         dsn?: scalar|null,
- *         hub_id?: scalar|null, // Default: null
- *         client_id?: scalar|null, // Default: null
- *         auto_log_stacks?: scalar|null, // Default: false
- *         release?: scalar|null, // Default: null
- *         environment?: scalar|null, // Default: null
- *         message_type?: scalar|null, // Default: 0
- *         parse_mode?: scalar|null, // Default: null
- *         disable_webpage_preview?: bool|null, // Default: null
- *         disable_notification?: bool|null, // Default: null
- *         split_long_messages?: bool, // Default: false
- *         delay_between_messages?: bool, // Default: false
- *         topic?: int, // Default: null
- *         factor?: int, // Default: 1
- *         tags?: list<scalar|null>,
+ *         title?: scalar|null|Param, // Default: null
+ *         host?: scalar|null|Param, // Default: null
+ *         port?: scalar|null|Param, // Default: 514
+ *         config?: list<scalar|null|Param>,
+ *         members?: list<scalar|null|Param>,
+ *         connection_string?: scalar|null|Param,
+ *         timeout?: scalar|null|Param,
+ *         time?: scalar|null|Param, // Default: 60
+ *         deduplication_level?: scalar|null|Param, // Default: 400
+ *         store?: scalar|null|Param, // Default: null
+ *         connection_timeout?: scalar|null|Param,
+ *         persistent?: bool|Param,
+ *         dsn?: scalar|null|Param,
+ *         hub_id?: scalar|null|Param, // Default: null
+ *         client_id?: scalar|null|Param, // Default: null
+ *         auto_log_stacks?: scalar|null|Param, // Default: false
+ *         release?: scalar|null|Param, // Default: null
+ *         environment?: scalar|null|Param, // Default: null
+ *         message_type?: scalar|null|Param, // Default: 0
+ *         parse_mode?: scalar|null|Param, // Default: null
+ *         disable_webpage_preview?: bool|null|Param, // Default: null
+ *         disable_notification?: bool|null|Param, // Default: null
+ *         split_long_messages?: bool|Param, // Default: false
+ *         delay_between_messages?: bool|Param, // Default: false
+ *         topic?: int|Param, // Default: null
+ *         factor?: int|Param, // Default: 1
+ *         tags?: list<scalar|null|Param>,
  *         console_formater_options?: mixed, // Deprecated: "monolog.handlers..console_formater_options.console_formater_options" is deprecated, use "monolog.handlers..console_formater_options.console_formatter_options" instead.
  *         console_formatter_options?: mixed, // Default: []
- *         formatter?: scalar|null,
- *         nested?: bool, // Default: false
+ *         formatter?: scalar|null|Param,
+ *         nested?: bool|Param, // Default: false
  *         publisher?: string|array{
- *             id?: scalar|null,
- *             hostname?: scalar|null,
- *             port?: scalar|null, // Default: 12201
- *             chunk_size?: scalar|null, // Default: 1420
- *             encoder?: "json"|"compressed_json",
+ *             id?: scalar|null|Param,
+ *             hostname?: scalar|null|Param,
+ *             port?: scalar|null|Param, // Default: 12201
+ *             chunk_size?: scalar|null|Param, // Default: 1420
+ *             encoder?: "json"|"compressed_json"|Param,
  *         },
  *         mongo?: string|array{
- *             id?: scalar|null,
- *             host?: scalar|null,
- *             port?: scalar|null, // Default: 27017
- *             user?: scalar|null,
- *             pass?: scalar|null,
- *             database?: scalar|null, // Default: "monolog"
- *             collection?: scalar|null, // Default: "logs"
+ *             id?: scalar|null|Param,
+ *             host?: scalar|null|Param,
+ *             port?: scalar|null|Param, // Default: 27017
+ *             user?: scalar|null|Param,
+ *             pass?: scalar|null|Param,
+ *             database?: scalar|null|Param, // Default: "monolog"
+ *             collection?: scalar|null|Param, // Default: "logs"
  *         },
  *         mongodb?: string|array{
- *             id?: scalar|null, // ID of a MongoDB\Client service
- *             uri?: scalar|null,
- *             username?: scalar|null,
- *             password?: scalar|null,
- *             database?: scalar|null, // Default: "monolog"
- *             collection?: scalar|null, // Default: "logs"
+ *             id?: scalar|null|Param, // ID of a MongoDB\Client service
+ *             uri?: scalar|null|Param,
+ *             username?: scalar|null|Param,
+ *             password?: scalar|null|Param,
+ *             database?: scalar|null|Param, // Default: "monolog"
+ *             collection?: scalar|null|Param, // Default: "logs"
  *         },
  *         elasticsearch?: string|array{
- *             id?: scalar|null,
- *             hosts?: list<scalar|null>,
- *             host?: scalar|null,
- *             port?: scalar|null, // Default: 9200
- *             transport?: scalar|null, // Default: "Http"
- *             user?: scalar|null, // Default: null
- *             password?: scalar|null, // Default: null
+ *             id?: scalar|null|Param,
+ *             hosts?: list<scalar|null|Param>,
+ *             host?: scalar|null|Param,
+ *             port?: scalar|null|Param, // Default: 9200
+ *             transport?: scalar|null|Param, // Default: "Http"
+ *             user?: scalar|null|Param, // Default: null
+ *             password?: scalar|null|Param, // Default: null
  *         },
- *         index?: scalar|null, // Default: "monolog"
- *         document_type?: scalar|null, // Default: "logs"
- *         ignore_error?: scalar|null, // Default: false
+ *         index?: scalar|null|Param, // Default: "monolog"
+ *         document_type?: scalar|null|Param, // Default: "logs"
+ *         ignore_error?: scalar|null|Param, // Default: false
  *         redis?: string|array{
- *             id?: scalar|null,
- *             host?: scalar|null,
- *             password?: scalar|null, // Default: null
- *             port?: scalar|null, // Default: 6379
- *             database?: scalar|null, // Default: 0
- *             key_name?: scalar|null, // Default: "monolog_redis"
+ *             id?: scalar|null|Param,
+ *             host?: scalar|null|Param,
+ *             password?: scalar|null|Param, // Default: null
+ *             port?: scalar|null|Param, // Default: 6379
+ *             database?: scalar|null|Param, // Default: 0
+ *             key_name?: scalar|null|Param, // Default: "monolog_redis"
  *         },
  *         predis?: string|array{
- *             id?: scalar|null,
- *             host?: scalar|null,
+ *             id?: scalar|null|Param,
+ *             host?: scalar|null|Param,
  *         },
- *         from_email?: scalar|null,
- *         to_email?: list<scalar|null>,
- *         subject?: scalar|null,
- *         content_type?: scalar|null, // Default: null
- *         headers?: list<scalar|null>,
- *         mailer?: scalar|null, // Default: null
+ *         from_email?: scalar|null|Param,
+ *         to_email?: list<scalar|null|Param>,
+ *         subject?: scalar|null|Param,
+ *         content_type?: scalar|null|Param, // Default: null
+ *         headers?: list<scalar|null|Param>,
+ *         mailer?: scalar|null|Param, // Default: null
  *         email_prototype?: string|array{
- *             id: scalar|null,
- *             method?: scalar|null, // Default: null
+ *             id: scalar|null|Param,
+ *             method?: scalar|null|Param, // Default: null
  *         },
- *         lazy?: bool, // Default: true
+ *         lazy?: bool|Param, // Default: true
  *         verbosity_levels?: array{
- *             VERBOSITY_QUIET?: scalar|null, // Default: "ERROR"
- *             VERBOSITY_NORMAL?: scalar|null, // Default: "WARNING"
- *             VERBOSITY_VERBOSE?: scalar|null, // Default: "NOTICE"
- *             VERBOSITY_VERY_VERBOSE?: scalar|null, // Default: "INFO"
- *             VERBOSITY_DEBUG?: scalar|null, // Default: "DEBUG"
+ *             VERBOSITY_QUIET?: scalar|null|Param, // Default: "ERROR"
+ *             VERBOSITY_NORMAL?: scalar|null|Param, // Default: "WARNING"
+ *             VERBOSITY_VERBOSE?: scalar|null|Param, // Default: "NOTICE"
+ *             VERBOSITY_VERY_VERBOSE?: scalar|null|Param, // Default: "INFO"
+ *             VERBOSITY_DEBUG?: scalar|null|Param, // Default: "DEBUG"
  *         },
  *         channels?: string|array{
- *             type?: scalar|null,
- *             elements?: list<scalar|null>,
+ *             type?: scalar|null|Param,
+ *             elements?: list<scalar|null|Param>,
  *         },
  *     }>,
  * }
  * @psalm-type DebugConfig = array{
- *     max_items?: int, // Max number of displayed items past the first level, -1 means no limit. // Default: 2500
- *     min_depth?: int, // Minimum tree depth to clone all the items, 1 is default. // Default: 1
- *     max_string_length?: int, // Max length of displayed strings, -1 means no limit. // Default: -1
- *     dump_destination?: scalar|null, // A stream URL where dumps should be written to. // Default: null
- *     theme?: "dark"|"light", // Changes the color of the dump() output when rendered directly on the templating. "dark" (default) or "light". // Default: "dark"
+ *     max_items?: int|Param, // Max number of displayed items past the first level, -1 means no limit. // Default: 2500
+ *     min_depth?: int|Param, // Minimum tree depth to clone all the items, 1 is default. // Default: 1
+ *     max_string_length?: int|Param, // Max length of displayed strings, -1 means no limit. // Default: -1
+ *     dump_destination?: scalar|null|Param, // A stream URL where dumps should be written to. // Default: null
+ *     theme?: "dark"|"light"|Param, // Changes the color of the dump() output when rendered directly on the templating. "dark" (default) or "light". // Default: "dark"
  * }
  * @psalm-type MakerConfig = array{
- *     root_namespace?: scalar|null, // Default: "App"
- *     generate_final_classes?: bool, // Default: true
- *     generate_final_entities?: bool, // Default: false
+ *     root_namespace?: scalar|null|Param, // Default: "App"
+ *     generate_final_classes?: bool|Param, // Default: true
+ *     generate_final_entities?: bool|Param, // Default: false
  * }
  * @psalm-type WebpackEncoreConfig = array{
- *     output_path: scalar|null, // The path where Encore is building the assets - i.e. Encore.setOutputPath()
- *     crossorigin?: false|"anonymous"|"use-credentials", // crossorigin value when Encore.enableIntegrityHashes() is used, can be false (default), anonymous or use-credentials // Default: false
- *     preload?: bool, // preload all rendered script and link tags automatically via the http2 Link header. // Default: false
- *     cache?: bool, // Enable caching of the entry point file(s) // Default: false
- *     strict_mode?: bool, // Throw an exception if the entrypoints.json file is missing or an entry is missing from the data // Default: true
- *     builds?: array<string, scalar|null>,
- *     script_attributes?: array<string, scalar|null>,
- *     link_attributes?: array<string, scalar|null>,
+ *     output_path: scalar|null|Param, // The path where Encore is building the assets - i.e. Encore.setOutputPath()
+ *     crossorigin?: false|"anonymous"|"use-credentials"|Param, // crossorigin value when Encore.enableIntegrityHashes() is used, can be false (default), anonymous or use-credentials // Default: false
+ *     preload?: bool|Param, // preload all rendered script and link tags automatically via the http2 Link header. // Default: false
+ *     cache?: bool|Param, // Enable caching of the entry point file(s) // Default: false
+ *     strict_mode?: bool|Param, // Throw an exception if the entrypoints.json file is missing or an entry is missing from the data // Default: true
+ *     builds?: array<string, scalar|null|Param>,
+ *     script_attributes?: array<string, scalar|null|Param>,
+ *     link_attributes?: array<string, scalar|null|Param>,
  * }
  * @psalm-type DatatablesConfig = array{
- *     language_from_cdn?: bool, // Load i18n data from DataTables CDN or locally // Default: true
- *     persist_state?: "none"|"query"|"fragment"|"local"|"session", // Where to persist the current table state automatically // Default: "fragment"
- *     method?: "GET"|"POST", // Default HTTP method to be used for callbacks // Default: "POST"
+ *     language_from_cdn?: bool|Param, // Load i18n data from DataTables CDN or locally // Default: true
+ *     persist_state?: "none"|"query"|"fragment"|"local"|"session"|Param, // Where to persist the current table state automatically // Default: "fragment"
+ *     method?: "GET"|"POST"|Param, // Default HTTP method to be used for callbacks // Default: "POST"
  *     options?: array<string, mixed>,
- *     renderer?: scalar|null, // Default service used to render templates, built-in TwigRenderer uses global Twig environment // Default: "Omines\\DataTablesBundle\\Twig\\TwigRenderer"
- *     template?: scalar|null, // Default template to be used for DataTables HTML // Default: "@DataTables/datatable_html.html.twig"
+ *     renderer?: scalar|null|Param, // Default service used to render templates, built-in TwigRenderer uses global Twig environment // Default: "Omines\\DataTablesBundle\\Twig\\TwigRenderer"
+ *     template?: scalar|null|Param, // Default template to be used for DataTables HTML // Default: "@DataTables/datatable_html.html.twig"
  *     template_parameters?: array{ // Default parameters to be passed to the template
- *         className?: scalar|null, // Default class attribute to apply to the root table elements // Default: "table table-bordered"
- *         columnFilter?: "thead"|"tfoot"|"both"|null, // If and where to enable the DataTables Filter module // Default: null
+ *         className?: scalar|null|Param, // Default class attribute to apply to the root table elements // Default: "table table-bordered"
+ *         columnFilter?: "thead"|"tfoot"|"both"|null|Param, // If and where to enable the DataTables Filter module // Default: null
  *         ...<mixed>
  *     },
- *     translation_domain?: scalar|null, // Default translation domain to be used // Default: "messages"
+ *     translation_domain?: scalar|null|Param, // Default translation domain to be used // Default: "messages"
  * }
  * @psalm-type LiipImagineConfig = array{
  *     resolvers?: array<string, array{ // Default: []
  *         web_path?: array{
- *             web_root?: scalar|null, // Default: "%kernel.project_dir%/public"
- *             cache_prefix?: scalar|null, // Default: "media/cache"
+ *             web_root?: scalar|null|Param, // Default: "%kernel.project_dir%/public"
+ *             cache_prefix?: scalar|null|Param, // Default: "media/cache"
  *         },
  *         aws_s3?: array{
- *             bucket: scalar|null,
- *             cache?: scalar|null, // Default: false
- *             use_psr_cache?: bool, // Default: false
- *             acl?: scalar|null, // Default: "public-read"
- *             cache_prefix?: scalar|null, // Default: ""
- *             client_id?: scalar|null, // Default: null
+ *             bucket: scalar|null|Param,
+ *             cache?: scalar|null|Param, // Default: false
+ *             use_psr_cache?: bool|Param, // Default: false
+ *             acl?: scalar|null|Param, // Default: "public-read"
+ *             cache_prefix?: scalar|null|Param, // Default: ""
+ *             client_id?: scalar|null|Param, // Default: null
  *             client_config: list<mixed>,
- *             get_options?: array<string, scalar|null>,
- *             put_options?: array<string, scalar|null>,
- *             proxies?: array<string, scalar|null>,
+ *             get_options?: array<string, scalar|null|Param>,
+ *             put_options?: array<string, scalar|null|Param>,
+ *             proxies?: array<string, scalar|null|Param>,
  *         },
  *         flysystem?: array{
- *             filesystem_service: scalar|null,
- *             cache_prefix?: scalar|null, // Default: ""
- *             root_url: scalar|null,
- *             visibility?: "public"|"private"|"noPredefinedVisibility", // Default: "public"
+ *             filesystem_service: scalar|null|Param,
+ *             cache_prefix?: scalar|null|Param, // Default: ""
+ *             root_url: scalar|null|Param,
+ *             visibility?: "public"|"private"|"noPredefinedVisibility"|Param, // Default: "public"
  *         },
  *     }>,
  *     loaders?: array<string, array{ // Default: []
  *         stream?: array{
- *             wrapper: scalar|null,
- *             context?: scalar|null, // Default: null
+ *             wrapper: scalar|null|Param,
+ *             context?: scalar|null|Param, // Default: null
  *         },
  *         filesystem?: array{
- *             locator?: "filesystem"|"filesystem_insecure", // Using the "filesystem_insecure" locator is not recommended due to a less secure resolver mechanism, but is provided for those using heavily symlinked projects. // Default: "filesystem"
- *             data_root?: list<scalar|null>,
- *             allow_unresolvable_data_roots?: bool, // Default: false
+ *             locator?: "filesystem"|"filesystem_insecure"|Param, // Using the "filesystem_insecure" locator is not recommended due to a less secure resolver mechanism, but is provided for those using heavily symlinked projects. // Default: "filesystem"
+ *             data_root?: list<scalar|null|Param>,
+ *             allow_unresolvable_data_roots?: bool|Param, // Default: false
  *             bundle_resources?: array{
- *                 enabled?: bool, // Default: false
- *                 access_control_type?: "blacklist"|"whitelist", // Sets the access control method applied to bundle names in "access_control_list" into a blacklist or whitelist. // Default: "blacklist"
- *                 access_control_list?: list<scalar|null>,
+ *                 enabled?: bool|Param, // Default: false
+ *                 access_control_type?: "blacklist"|"whitelist"|Param, // Sets the access control method applied to bundle names in "access_control_list" into a blacklist or whitelist. // Default: "blacklist"
+ *                 access_control_list?: list<scalar|null|Param>,
  *             },
  *         },
  *         flysystem?: array{
- *             filesystem_service: scalar|null,
+ *             filesystem_service: scalar|null|Param,
  *         },
  *         chain?: array{
- *             loaders: list<scalar|null>,
+ *             loaders: list<scalar|null|Param>,
  *         },
  *     }>,
- *     driver?: scalar|null, // Default: "gd"
- *     cache?: scalar|null, // Default: "default"
- *     cache_base_path?: scalar|null, // Default: ""
- *     data_loader?: scalar|null, // Default: "default"
- *     default_image?: scalar|null, // Default: null
+ *     driver?: scalar|null|Param, // Default: "gd"
+ *     cache?: scalar|null|Param, // Default: "default"
+ *     cache_base_path?: scalar|null|Param, // Default: ""
+ *     data_loader?: scalar|null|Param, // Default: "default"
+ *     default_image?: scalar|null|Param, // Default: null
  *     default_filter_set_settings?: array{
- *         quality?: scalar|null, // Default: 100
- *         jpeg_quality?: scalar|null, // Default: null
- *         png_compression_level?: scalar|null, // Default: null
- *         png_compression_filter?: scalar|null, // Default: null
- *         format?: scalar|null, // Default: null
- *         animated?: bool, // Default: false
- *         cache?: scalar|null, // Default: null
- *         data_loader?: scalar|null, // Default: null
- *         default_image?: scalar|null, // Default: null
+ *         quality?: scalar|null|Param, // Default: 100
+ *         jpeg_quality?: scalar|null|Param, // Default: null
+ *         png_compression_level?: scalar|null|Param, // Default: null
+ *         png_compression_filter?: scalar|null|Param, // Default: null
+ *         format?: scalar|null|Param, // Default: null
+ *         animated?: bool|Param, // Default: false
+ *         cache?: scalar|null|Param, // Default: null
+ *         data_loader?: scalar|null|Param, // Default: null
+ *         default_image?: scalar|null|Param, // Default: null
  *         filters?: array<string, array<string, mixed>>,
  *         post_processors?: array<string, array<string, mixed>>,
  *     },
  *     controller?: array{
- *         filter_action?: scalar|null, // Default: "Liip\\ImagineBundle\\Controller\\ImagineController::filterAction"
- *         filter_runtime_action?: scalar|null, // Default: "Liip\\ImagineBundle\\Controller\\ImagineController::filterRuntimeAction"
- *         redirect_response_code?: int, // Default: 302
+ *         filter_action?: scalar|null|Param, // Default: "Liip\\ImagineBundle\\Controller\\ImagineController::filterAction"
+ *         filter_runtime_action?: scalar|null|Param, // Default: "Liip\\ImagineBundle\\Controller\\ImagineController::filterRuntimeAction"
+ *         redirect_response_code?: int|Param, // Default: 302
  *     },
  *     filter_sets?: array<string, array{ // Default: []
- *         quality?: scalar|null,
- *         jpeg_quality?: scalar|null,
- *         png_compression_level?: scalar|null,
- *         png_compression_filter?: scalar|null,
- *         format?: scalar|null,
- *         animated?: bool,
- *         cache?: scalar|null,
- *         data_loader?: scalar|null,
- *         default_image?: scalar|null,
+ *         quality?: scalar|null|Param,
+ *         jpeg_quality?: scalar|null|Param,
+ *         png_compression_level?: scalar|null|Param,
+ *         png_compression_filter?: scalar|null|Param,
+ *         format?: scalar|null|Param,
+ *         animated?: bool|Param,
+ *         cache?: scalar|null|Param,
+ *         data_loader?: scalar|null|Param,
+ *         default_image?: scalar|null|Param,
  *         filters?: array<string, array<string, mixed>>,
  *         post_processors?: array<string, array<string, mixed>>,
  *     }>,
  *     twig?: array{
- *         mode?: "none"|"lazy"|"legacy", // Twig mode: none/lazy/legacy (default) // Default: "legacy"
- *         assets_version?: scalar|null, // Default: null
+ *         mode?: "none"|"lazy"|"legacy"|Param, // Twig mode: none/lazy/legacy (default) // Default: "legacy"
+ *         assets_version?: scalar|null|Param, // Default: null
  *     },
- *     enqueue?: bool, // Enables integration with enqueue if set true. Allows resolve image caches in background by sending messages to MQ. // Default: false
+ *     enqueue?: bool|Param, // Enables integration with enqueue if set true. Allows resolve image caches in background by sending messages to MQ. // Default: false
  *     messenger?: bool|array{ // Enables integration with symfony/messenger if set true. Warmup image caches in background by sending messages to MQ.
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
- *     templating?: bool, // Enables integration with symfony/templating component // Default: true
+ *     templating?: bool|Param, // Enables integration with symfony/templating component // Default: true
  *     webp?: array{
- *         generate?: bool, // Default: false
- *         quality?: int, // Default: 100
- *         cache?: scalar|null, // Default: null
- *         data_loader?: scalar|null, // Default: null
+ *         generate?: bool|Param, // Default: false
+ *         quality?: int|Param, // Default: 100
+ *         cache?: scalar|null|Param, // Default: null
+ *         data_loader?: scalar|null|Param, // Default: null
  *         post_processors?: array<string, array<string, mixed>>,
  *     },
  * }
  * @psalm-type DamaDoctrineTestConfig = array{
  *     enable_static_connection?: mixed, // Default: true
- *     enable_static_meta_data_cache?: bool, // Default: true
- *     enable_static_query_cache?: bool, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
  *     connection_keys?: list<mixed>,
  * }
  * @psalm-type TwigExtraConfig = array{
  *     cache?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     html?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     markdown?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     intl?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     cssinliner?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     inky?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     string?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     commonmark?: array{
  *         renderer?: array{ // Array of options for rendering HTML.
- *             block_separator?: scalar|null,
- *             inner_separator?: scalar|null,
- *             soft_break?: scalar|null,
+ *             block_separator?: scalar|null|Param,
+ *             inner_separator?: scalar|null|Param,
+ *             soft_break?: scalar|null|Param,
  *         },
- *         html_input?: "strip"|"allow"|"escape", // How to handle HTML input.
- *         allow_unsafe_links?: bool, // Remove risky link and image URLs by setting this to false. // Default: true
- *         max_nesting_level?: int, // The maximum nesting level for blocks. // Default: 9223372036854775807
- *         max_delimiters_per_line?: int, // The maximum number of strong/emphasis delimiters per line. // Default: 9223372036854775807
+ *         html_input?: "strip"|"allow"|"escape"|Param, // How to handle HTML input.
+ *         allow_unsafe_links?: bool|Param, // Remove risky link and image URLs by setting this to false. // Default: true
+ *         max_nesting_level?: int|Param, // The maximum nesting level for blocks. // Default: 9223372036854775807
+ *         max_delimiters_per_line?: int|Param, // The maximum number of strong/emphasis delimiters per line. // Default: 9223372036854775807
  *         slug_normalizer?: array{ // Array of options for configuring how URL-safe slugs are created.
  *             instance?: mixed,
- *             max_length?: int, // Default: 255
+ *             max_length?: int|Param, // Default: 255
  *             unique?: mixed,
  *         },
  *         commonmark?: array{ // Array of options for configuring the CommonMark core extension.
- *             enable_em?: bool, // Default: true
- *             enable_strong?: bool, // Default: true
- *             use_asterisk?: bool, // Default: true
- *             use_underscore?: bool, // Default: true
- *             unordered_list_markers?: list<scalar|null>,
+ *             enable_em?: bool|Param, // Default: true
+ *             enable_strong?: bool|Param, // Default: true
+ *             use_asterisk?: bool|Param, // Default: true
+ *             use_underscore?: bool|Param, // Default: true
+ *             unordered_list_markers?: list<scalar|null|Param>,
  *         },
  *         ...<mixed>
  *     },
  * }
  * @psalm-type GregwarCaptchaConfig = array{
- *     length?: scalar|null, // Default: 5
- *     width?: scalar|null, // Default: 130
- *     height?: scalar|null, // Default: 50
- *     font?: scalar|null, // Default: "C:\\Users\\mail\\Documents\\PHP\\Part-DB-server\\vendor\\gregwar\\captcha-bundle\\DependencyInjection/../Generator/Font/captcha.ttf"
- *     keep_value?: scalar|null, // Default: false
- *     charset?: scalar|null, // Default: "abcdefhjkmnprstuvwxyz23456789"
- *     as_file?: scalar|null, // Default: false
- *     as_url?: scalar|null, // Default: false
- *     reload?: scalar|null, // Default: false
- *     image_folder?: scalar|null, // Default: "captcha"
- *     web_path?: scalar|null, // Default: "%kernel.project_dir%/public"
- *     gc_freq?: scalar|null, // Default: 100
- *     expiration?: scalar|null, // Default: 60
- *     quality?: scalar|null, // Default: 50
- *     invalid_message?: scalar|null, // Default: "Bad code value"
- *     bypass_code?: scalar|null, // Default: null
- *     whitelist_key?: scalar|null, // Default: "captcha_whitelist_key"
- *     humanity?: scalar|null, // Default: 0
- *     distortion?: scalar|null, // Default: true
- *     max_front_lines?: scalar|null, // Default: null
- *     max_behind_lines?: scalar|null, // Default: null
- *     interpolation?: scalar|null, // Default: true
- *     text_color?: list<scalar|null>,
- *     background_color?: list<scalar|null>,
- *     background_images?: list<scalar|null>,
- *     disabled?: scalar|null, // Default: false
- *     ignore_all_effects?: scalar|null, // Default: false
- *     session_key?: scalar|null, // Default: "captcha"
+ *     length?: scalar|null|Param, // Default: 5
+ *     width?: scalar|null|Param, // Default: 130
+ *     height?: scalar|null|Param, // Default: 50
+ *     font?: scalar|null|Param, // Default: "C:\\Users\\mail\\Documents\\PHP\\Part-DB-server\\vendor\\gregwar\\captcha-bundle\\DependencyInjection/../Generator/Font/captcha.ttf"
+ *     keep_value?: scalar|null|Param, // Default: false
+ *     charset?: scalar|null|Param, // Default: "abcdefhjkmnprstuvwxyz23456789"
+ *     as_file?: scalar|null|Param, // Default: false
+ *     as_url?: scalar|null|Param, // Default: false
+ *     reload?: scalar|null|Param, // Default: false
+ *     image_folder?: scalar|null|Param, // Default: "captcha"
+ *     web_path?: scalar|null|Param, // Default: "%kernel.project_dir%/public"
+ *     gc_freq?: scalar|null|Param, // Default: 100
+ *     expiration?: scalar|null|Param, // Default: 60
+ *     quality?: scalar|null|Param, // Default: 50
+ *     invalid_message?: scalar|null|Param, // Default: "Bad code value"
+ *     bypass_code?: scalar|null|Param, // Default: null
+ *     whitelist_key?: scalar|null|Param, // Default: "captcha_whitelist_key"
+ *     humanity?: scalar|null|Param, // Default: 0
+ *     distortion?: scalar|null|Param, // Default: true
+ *     max_front_lines?: scalar|null|Param, // Default: null
+ *     max_behind_lines?: scalar|null|Param, // Default: null
+ *     interpolation?: scalar|null|Param, // Default: true
+ *     text_color?: list<scalar|null|Param>,
+ *     background_color?: list<scalar|null|Param>,
+ *     background_images?: list<scalar|null|Param>,
+ *     disabled?: scalar|null|Param, // Default: false
+ *     ignore_all_effects?: scalar|null|Param, // Default: false
+ *     session_key?: scalar|null|Param, // Default: "captcha"
  * }
  * @psalm-type FlorianvSwapConfig = array{
  *     cache?: array{
- *         ttl?: int, // Default: 3600
- *         type?: scalar|null, // A cache type or service id // Default: null
+ *         ttl?: int|Param, // Default: 3600
+ *         type?: scalar|null|Param, // A cache type or service id // Default: null
  *     },
  *     providers?: array{
  *         apilayer_fixer?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         apilayer_currency_data?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         apilayer_exchange_rates_data?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         abstract_api?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         fixer?: array{
- *             priority?: int, // Default: 0
- *             access_key: scalar|null,
- *             enterprise?: bool, // Default: false
+ *             priority?: int|Param, // Default: 0
+ *             access_key: scalar|null|Param,
+ *             enterprise?: bool|Param, // Default: false
  *         },
  *         cryptonator?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         exchange_rates_api?: array{
- *             priority?: int, // Default: 0
- *             access_key: scalar|null,
- *             enterprise?: bool, // Default: false
+ *             priority?: int|Param, // Default: 0
+ *             access_key: scalar|null|Param,
+ *             enterprise?: bool|Param, // Default: false
  *         },
  *         webservicex?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         central_bank_of_czech_republic?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         central_bank_of_republic_turkey?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         european_central_bank?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         national_bank_of_romania?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         russian_central_bank?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         frankfurter?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         fawazahmed_currency_api?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         bulgarian_national_bank?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         national_bank_of_ukraine?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *         },
  *         currency_data_feed?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         currency_layer?: array{
- *             priority?: int, // Default: 0
- *             access_key: scalar|null,
- *             enterprise?: bool, // Default: false
+ *             priority?: int|Param, // Default: 0
+ *             access_key: scalar|null|Param,
+ *             enterprise?: bool|Param, // Default: false
  *         },
  *         forge?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         open_exchange_rates?: array{
- *             priority?: int, // Default: 0
- *             app_id: scalar|null,
- *             enterprise?: bool, // Default: false
+ *             priority?: int|Param, // Default: 0
+ *             app_id: scalar|null|Param,
+ *             enterprise?: bool|Param, // Default: false
  *         },
  *         xignite?: array{
- *             priority?: int, // Default: 0
- *             token: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             token: scalar|null|Param,
  *         },
  *         xchangeapi?: array{
- *             priority?: int, // Default: 0
- *             api_key: scalar|null,
+ *             priority?: int|Param, // Default: 0
+ *             api_key: scalar|null|Param,
  *         },
  *         currency_converter?: array{
- *             priority?: int, // Default: 0
- *             access_key: scalar|null,
- *             enterprise?: bool, // Default: false
+ *             priority?: int|Param, // Default: 0
+ *             access_key: scalar|null|Param,
+ *             enterprise?: bool|Param, // Default: false
  *         },
  *         array?: array{
- *             priority?: int, // Default: 0
+ *             priority?: int|Param, // Default: 0
  *             latestRates: mixed,
  *             historicalRates?: mixed,
  *         },
@@ -1865,133 +1867,133 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * }
  * @psalm-type NelmioSecurityConfig = array{
  *     signed_cookie?: array{
- *         names?: list<scalar|null>,
- *         secret?: scalar|null, // Default: "%kernel.secret%"
- *         hash_algo?: scalar|null,
- *         legacy_hash_algo?: scalar|null, // Fallback algorithm to allow for frictionless hash algorithm upgrades. Use with caution and as a temporary measure as it allows for downgrade attacks. // Default: null
- *         separator?: scalar|null, // Default: "."
+ *         names?: list<scalar|null|Param>,
+ *         secret?: scalar|null|Param, // Default: "%kernel.secret%"
+ *         hash_algo?: scalar|null|Param,
+ *         legacy_hash_algo?: scalar|null|Param, // Fallback algorithm to allow for frictionless hash algorithm upgrades. Use with caution and as a temporary measure as it allows for downgrade attacks. // Default: null
+ *         separator?: scalar|null|Param, // Default: "."
  *     },
  *     clickjacking?: array{
- *         hosts?: list<scalar|null>,
+ *         hosts?: list<scalar|null|Param>,
  *         paths?: array<string, array{ // Default: {"^/.*":{"header":"DENY"}}
- *             header?: scalar|null, // Default: "DENY"
+ *             header?: scalar|null|Param, // Default: "DENY"
  *         }>,
- *         content_types?: list<scalar|null>,
+ *         content_types?: list<scalar|null|Param>,
  *     },
  *     external_redirects?: array{
- *         abort?: bool, // Default: false
- *         override?: scalar|null, // Default: null
- *         forward_as?: scalar|null, // Default: null
- *         log?: bool, // Default: false
- *         allow_list?: list<scalar|null>,
+ *         abort?: bool|Param, // Default: false
+ *         override?: scalar|null|Param, // Default: null
+ *         forward_as?: scalar|null|Param, // Default: null
+ *         log?: bool|Param, // Default: false
+ *         allow_list?: list<scalar|null|Param>,
  *     },
  *     flexible_ssl?: bool|array{
- *         enabled?: bool, // Default: false
- *         cookie_name?: scalar|null, // Default: "auth"
- *         unsecured_logout?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
+ *         cookie_name?: scalar|null|Param, // Default: "auth"
+ *         unsecured_logout?: bool|Param, // Default: false
  *     },
  *     forced_ssl?: bool|array{
- *         enabled?: bool, // Default: false
- *         hsts_max_age?: scalar|null, // Default: null
- *         hsts_subdomains?: bool, // Default: false
- *         hsts_preload?: bool, // Default: false
- *         allow_list?: list<scalar|null>,
- *         hosts?: list<scalar|null>,
- *         redirect_status_code?: scalar|null, // Default: 302
+ *         enabled?: bool|Param, // Default: false
+ *         hsts_max_age?: scalar|null|Param, // Default: null
+ *         hsts_subdomains?: bool|Param, // Default: false
+ *         hsts_preload?: bool|Param, // Default: false
+ *         allow_list?: list<scalar|null|Param>,
+ *         hosts?: list<scalar|null|Param>,
+ *         redirect_status_code?: scalar|null|Param, // Default: 302
  *     },
  *     content_type?: array{
- *         nosniff?: bool, // Default: false
+ *         nosniff?: bool|Param, // Default: false
  *     },
  *     xss_protection?: array{ // Deprecated: The "xss_protection" option is deprecated, use Content Security Policy without allowing "unsafe-inline" scripts instead.
- *         enabled?: bool, // Default: false
- *         mode_block?: bool, // Default: false
- *         report_uri?: scalar|null, // Default: null
+ *         enabled?: bool|Param, // Default: false
+ *         mode_block?: bool|Param, // Default: false
+ *         report_uri?: scalar|null|Param, // Default: null
  *     },
  *     csp?: bool|array{
- *         enabled?: bool, // Default: true
- *         request_matcher?: scalar|null, // Default: null
- *         hosts?: list<scalar|null>,
- *         content_types?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         request_matcher?: scalar|null|Param, // Default: null
+ *         hosts?: list<scalar|null|Param>,
+ *         content_types?: list<scalar|null|Param>,
  *         report_endpoint?: array{
- *             log_channel?: scalar|null, // Default: null
- *             log_formatter?: scalar|null, // Default: "nelmio_security.csp_report.log_formatter"
- *             log_level?: "alert"|"critical"|"debug"|"emergency"|"error"|"info"|"notice"|"warning", // Default: "notice"
+ *             log_channel?: scalar|null|Param, // Default: null
+ *             log_formatter?: scalar|null|Param, // Default: "nelmio_security.csp_report.log_formatter"
+ *             log_level?: "alert"|"critical"|"debug"|"emergency"|"error"|"info"|"notice"|"warning"|Param, // Default: "notice"
  *             filters?: array{
- *                 domains?: bool, // Default: true
- *                 schemes?: bool, // Default: true
- *                 browser_bugs?: bool, // Default: true
- *                 injected_scripts?: bool, // Default: true
+ *                 domains?: bool|Param, // Default: true
+ *                 schemes?: bool|Param, // Default: true
+ *                 browser_bugs?: bool|Param, // Default: true
+ *                 injected_scripts?: bool|Param, // Default: true
  *             },
- *             dismiss?: list<list<"default-src"|"base-uri"|"block-all-mixed-content"|"child-src"|"connect-src"|"font-src"|"form-action"|"frame-ancestors"|"frame-src"|"img-src"|"manifest-src"|"media-src"|"object-src"|"plugin-types"|"script-src"|"style-src"|"upgrade-insecure-requests"|"report-uri"|"worker-src"|"prefetch-src"|"report-to"|"*">>,
+ *             dismiss?: list<list<"default-src"|"base-uri"|"block-all-mixed-content"|"child-src"|"connect-src"|"font-src"|"form-action"|"frame-ancestors"|"frame-src"|"img-src"|"manifest-src"|"media-src"|"object-src"|"plugin-types"|"script-src"|"style-src"|"upgrade-insecure-requests"|"report-uri"|"worker-src"|"prefetch-src"|"report-to"|"*"|Param>>,
  *         },
- *         compat_headers?: bool, // Default: true
- *         report_logger_service?: scalar|null, // Default: "logger"
+ *         compat_headers?: bool|Param, // Default: true
+ *         report_logger_service?: scalar|null|Param, // Default: "logger"
  *         hash?: array{
- *             algorithm?: "sha256"|"sha384"|"sha512", // The algorithm to use for hashes // Default: "sha256"
+ *             algorithm?: "sha256"|"sha384"|"sha512"|Param, // The algorithm to use for hashes // Default: "sha256"
  *         },
  *         report?: array{
- *             level1_fallback?: bool, // Provides CSP Level 1 fallback when using hash or nonce (CSP level 2) by adding 'unsafe-inline' source. See https://www.w3.org/TR/CSP2/#directive-script-src and https://www.w3.org/TR/CSP2/#directive-style-src // Default: true
+ *             level1_fallback?: bool|Param, // Provides CSP Level 1 fallback when using hash or nonce (CSP level 2) by adding 'unsafe-inline' source. See https://www.w3.org/TR/CSP2/#directive-script-src and https://www.w3.org/TR/CSP2/#directive-style-src // Default: true
  *             browser_adaptive?: bool|array{ // Do not send directives that browser do not support
- *                 enabled?: bool, // Default: false
- *                 parser?: scalar|null, // Default: "nelmio_security.ua_parser.ua_php"
+ *                 enabled?: bool|Param, // Default: false
+ *                 parser?: scalar|null|Param, // Default: "nelmio_security.ua_parser.ua_php"
  *             },
- *             default-src?: list<scalar|null>,
- *             base-uri?: list<scalar|null>,
- *             block-all-mixed-content?: bool, // Default: false
- *             child-src?: list<scalar|null>,
- *             connect-src?: list<scalar|null>,
- *             font-src?: list<scalar|null>,
- *             form-action?: list<scalar|null>,
- *             frame-ancestors?: list<scalar|null>,
- *             frame-src?: list<scalar|null>,
- *             img-src?: list<scalar|null>,
- *             manifest-src?: list<scalar|null>,
- *             media-src?: list<scalar|null>,
- *             object-src?: list<scalar|null>,
- *             plugin-types?: list<scalar|null>,
- *             script-src?: list<scalar|null>,
- *             style-src?: list<scalar|null>,
- *             upgrade-insecure-requests?: bool, // Default: false
- *             report-uri?: list<scalar|null>,
- *             worker-src?: list<scalar|null>,
- *             prefetch-src?: list<scalar|null>,
- *             report-to?: scalar|null,
+ *             default-src?: list<scalar|null|Param>,
+ *             base-uri?: list<scalar|null|Param>,
+ *             block-all-mixed-content?: bool|Param, // Default: false
+ *             child-src?: list<scalar|null|Param>,
+ *             connect-src?: list<scalar|null|Param>,
+ *             font-src?: list<scalar|null|Param>,
+ *             form-action?: list<scalar|null|Param>,
+ *             frame-ancestors?: list<scalar|null|Param>,
+ *             frame-src?: list<scalar|null|Param>,
+ *             img-src?: list<scalar|null|Param>,
+ *             manifest-src?: list<scalar|null|Param>,
+ *             media-src?: list<scalar|null|Param>,
+ *             object-src?: list<scalar|null|Param>,
+ *             plugin-types?: list<scalar|null|Param>,
+ *             script-src?: list<scalar|null|Param>,
+ *             style-src?: list<scalar|null|Param>,
+ *             upgrade-insecure-requests?: bool|Param, // Default: false
+ *             report-uri?: list<scalar|null|Param>,
+ *             worker-src?: list<scalar|null|Param>,
+ *             prefetch-src?: list<scalar|null|Param>,
+ *             report-to?: scalar|null|Param,
  *         },
  *         enforce?: array{
- *             level1_fallback?: bool, // Provides CSP Level 1 fallback when using hash or nonce (CSP level 2) by adding 'unsafe-inline' source. See https://www.w3.org/TR/CSP2/#directive-script-src and https://www.w3.org/TR/CSP2/#directive-style-src // Default: true
+ *             level1_fallback?: bool|Param, // Provides CSP Level 1 fallback when using hash or nonce (CSP level 2) by adding 'unsafe-inline' source. See https://www.w3.org/TR/CSP2/#directive-script-src and https://www.w3.org/TR/CSP2/#directive-style-src // Default: true
  *             browser_adaptive?: bool|array{ // Do not send directives that browser do not support
- *                 enabled?: bool, // Default: false
- *                 parser?: scalar|null, // Default: "nelmio_security.ua_parser.ua_php"
+ *                 enabled?: bool|Param, // Default: false
+ *                 parser?: scalar|null|Param, // Default: "nelmio_security.ua_parser.ua_php"
  *             },
- *             default-src?: list<scalar|null>,
- *             base-uri?: list<scalar|null>,
- *             block-all-mixed-content?: bool, // Default: false
- *             child-src?: list<scalar|null>,
- *             connect-src?: list<scalar|null>,
- *             font-src?: list<scalar|null>,
- *             form-action?: list<scalar|null>,
- *             frame-ancestors?: list<scalar|null>,
- *             frame-src?: list<scalar|null>,
- *             img-src?: list<scalar|null>,
- *             manifest-src?: list<scalar|null>,
- *             media-src?: list<scalar|null>,
- *             object-src?: list<scalar|null>,
- *             plugin-types?: list<scalar|null>,
- *             script-src?: list<scalar|null>,
- *             style-src?: list<scalar|null>,
- *             upgrade-insecure-requests?: bool, // Default: false
- *             report-uri?: list<scalar|null>,
- *             worker-src?: list<scalar|null>,
- *             prefetch-src?: list<scalar|null>,
- *             report-to?: scalar|null,
+ *             default-src?: list<scalar|null|Param>,
+ *             base-uri?: list<scalar|null|Param>,
+ *             block-all-mixed-content?: bool|Param, // Default: false
+ *             child-src?: list<scalar|null|Param>,
+ *             connect-src?: list<scalar|null|Param>,
+ *             font-src?: list<scalar|null|Param>,
+ *             form-action?: list<scalar|null|Param>,
+ *             frame-ancestors?: list<scalar|null|Param>,
+ *             frame-src?: list<scalar|null|Param>,
+ *             img-src?: list<scalar|null|Param>,
+ *             manifest-src?: list<scalar|null|Param>,
+ *             media-src?: list<scalar|null|Param>,
+ *             object-src?: list<scalar|null|Param>,
+ *             plugin-types?: list<scalar|null|Param>,
+ *             script-src?: list<scalar|null|Param>,
+ *             style-src?: list<scalar|null|Param>,
+ *             upgrade-insecure-requests?: bool|Param, // Default: false
+ *             report-uri?: list<scalar|null|Param>,
+ *             worker-src?: list<scalar|null|Param>,
+ *             prefetch-src?: list<scalar|null|Param>,
+ *             report-to?: scalar|null|Param,
  *         },
  *     },
  *     referrer_policy?: bool|array{
- *         enabled?: bool, // Default: false
- *         policies?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         policies?: list<scalar|null|Param>,
  *     },
  *     permissions_policy?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         policies?: array{
  *             accelerometer?: mixed, // Default: null
  *             ambient_light_sensor?: mixed, // Default: null
@@ -2040,517 +2042,517 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * }
  * @psalm-type TurboConfig = array{
  *     broadcast?: bool|array{
- *         enabled?: bool, // Default: true
- *         entity_template_prefixes?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: true
+ *         entity_template_prefixes?: list<scalar|null|Param>,
  *         doctrine_orm?: bool|array{ // Enable the Doctrine ORM integration
- *             enabled?: bool, // Default: true
+ *             enabled?: bool|Param, // Default: true
  *         },
  *     },
- *     default_transport?: scalar|null, // Default: "default"
+ *     default_transport?: scalar|null|Param, // Default: "default"
  * }
  * @psalm-type TfaWebauthnConfig = array{
- *     enabled?: scalar|null, // Default: false
- *     timeout?: int, // Default: 60000
- *     rpID?: scalar|null, // Default: null
- *     rpName?: scalar|null, // Default: "Webauthn Application"
- *     rpIcon?: scalar|null, // Default: null
- *     template?: scalar|null, // Default: "@TFAWebauthn/Authentication/form.html.twig"
- *     U2FAppID?: scalar|null, // Default: null
+ *     enabled?: scalar|null|Param, // Default: false
+ *     timeout?: int|Param, // Default: 60000
+ *     rpID?: scalar|null|Param, // Default: null
+ *     rpName?: scalar|null|Param, // Default: "Webauthn Application"
+ *     rpIcon?: scalar|null|Param, // Default: null
+ *     template?: scalar|null|Param, // Default: "@TFAWebauthn/Authentication/form.html.twig"
+ *     U2FAppID?: scalar|null|Param, // Default: null
  * }
  * @psalm-type SchebTwoFactorConfig = array{
- *     persister?: scalar|null, // Default: "scheb_two_factor.persister.doctrine"
- *     model_manager_name?: scalar|null, // Default: null
- *     security_tokens?: list<scalar|null>,
- *     ip_whitelist?: list<scalar|null>,
- *     ip_whitelist_provider?: scalar|null, // Default: "scheb_two_factor.default_ip_whitelist_provider"
- *     two_factor_token_factory?: scalar|null, // Default: "scheb_two_factor.default_token_factory"
- *     two_factor_provider_decider?: scalar|null, // Default: "scheb_two_factor.default_provider_decider"
- *     two_factor_condition?: scalar|null, // Default: null
- *     code_reuse_cache?: scalar|null, // Default: null
- *     code_reuse_cache_duration?: int, // Default: 60
- *     code_reuse_default_handler?: scalar|null, // Default: null
+ *     persister?: scalar|null|Param, // Default: "scheb_two_factor.persister.doctrine"
+ *     model_manager_name?: scalar|null|Param, // Default: null
+ *     security_tokens?: list<scalar|null|Param>,
+ *     ip_whitelist?: list<scalar|null|Param>,
+ *     ip_whitelist_provider?: scalar|null|Param, // Default: "scheb_two_factor.default_ip_whitelist_provider"
+ *     two_factor_token_factory?: scalar|null|Param, // Default: "scheb_two_factor.default_token_factory"
+ *     two_factor_provider_decider?: scalar|null|Param, // Default: "scheb_two_factor.default_provider_decider"
+ *     two_factor_condition?: scalar|null|Param, // Default: null
+ *     code_reuse_cache?: scalar|null|Param, // Default: null
+ *     code_reuse_cache_duration?: int|Param, // Default: 60
+ *     code_reuse_default_handler?: scalar|null|Param, // Default: null
  *     trusted_device?: bool|array{
- *         enabled?: scalar|null, // Default: false
- *         manager?: scalar|null, // Default: "scheb_two_factor.default_trusted_device_manager"
- *         lifetime?: int, // Default: 5184000
- *         extend_lifetime?: bool, // Default: false
- *         key?: scalar|null, // Default: null
- *         cookie_name?: scalar|null, // Default: "trusted_device"
- *         cookie_secure?: true|false|"auto", // Default: "auto"
- *         cookie_domain?: scalar|null, // Default: null
- *         cookie_path?: scalar|null, // Default: "/"
- *         cookie_same_site?: scalar|null, // Default: "lax"
+ *         enabled?: scalar|null|Param, // Default: false
+ *         manager?: scalar|null|Param, // Default: "scheb_two_factor.default_trusted_device_manager"
+ *         lifetime?: int|Param, // Default: 5184000
+ *         extend_lifetime?: bool|Param, // Default: false
+ *         key?: scalar|null|Param, // Default: null
+ *         cookie_name?: scalar|null|Param, // Default: "trusted_device"
+ *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
+ *         cookie_domain?: scalar|null|Param, // Default: null
+ *         cookie_path?: scalar|null|Param, // Default: "/"
+ *         cookie_same_site?: scalar|null|Param, // Default: "lax"
  *     },
  *     backup_codes?: bool|array{
- *         enabled?: scalar|null, // Default: false
- *         manager?: scalar|null, // Default: "scheb_two_factor.default_backup_code_manager"
+ *         enabled?: scalar|null|Param, // Default: false
+ *         manager?: scalar|null|Param, // Default: "scheb_two_factor.default_backup_code_manager"
  *     },
  *     google?: bool|array{
- *         enabled?: scalar|null, // Default: false
- *         form_renderer?: scalar|null, // Default: null
- *         issuer?: scalar|null, // Default: null
- *         server_name?: scalar|null, // Default: null
- *         template?: scalar|null, // Default: "@SchebTwoFactor/Authentication/form.html.twig"
- *         digits?: int, // Default: 6
- *         leeway?: int, // Default: 0
+ *         enabled?: scalar|null|Param, // Default: false
+ *         form_renderer?: scalar|null|Param, // Default: null
+ *         issuer?: scalar|null|Param, // Default: null
+ *         server_name?: scalar|null|Param, // Default: null
+ *         template?: scalar|null|Param, // Default: "@SchebTwoFactor/Authentication/form.html.twig"
+ *         digits?: int|Param, // Default: 6
+ *         leeway?: int|Param, // Default: 0
  *     },
  * }
  * @psalm-type WebauthnConfig = array{
- *     fake_credential_generator?: scalar|null, // A service that implements the FakeCredentialGenerator to generate fake credentials for preventing username enumeration. // Default: "Webauthn\\SimpleFakeCredentialGenerator"
- *     clock?: scalar|null, // PSR-20 Clock service. // Default: "webauthn.clock.default"
- *     options_storage?: scalar|null, // Service responsible of the options/user entity storage during the ceremony // Default: "Webauthn\\Bundle\\Security\\Storage\\SessionStorage"
- *     event_dispatcher?: scalar|null, // PSR-14 Event Dispatcher service. // Default: "Psr\\EventDispatcher\\EventDispatcherInterface"
- *     http_client?: scalar|null, // A Symfony HTTP client. // Default: "webauthn.http_client.default"
- *     logger?: scalar|null, // A PSR-3 logger to receive logs during the processes // Default: "webauthn.logger.default"
- *     credential_repository?: scalar|null, // This repository is responsible of the credential storage // Default: "Webauthn\\Bundle\\Repository\\DummyPublicKeyCredentialSourceRepository"
- *     user_repository?: scalar|null, // This repository is responsible of the user storage // Default: "Webauthn\\Bundle\\Repository\\DummyPublicKeyCredentialUserEntityRepository"
- *     allowed_origins?: array<string, scalar|null>,
- *     allow_subdomains?: bool, // Default: false
- *     secured_rp_ids?: array<string, scalar|null>,
- *     counter_checker?: scalar|null, // This service will check if the counter is valid. By default it throws an exception (recommended). // Default: "Webauthn\\Counter\\ThrowExceptionIfInvalid"
- *     top_origin_validator?: scalar|null, // For cross origin (e.g. iframe), this service will be in charge of verifying the top origin. // Default: null
+ *     fake_credential_generator?: scalar|null|Param, // A service that implements the FakeCredentialGenerator to generate fake credentials for preventing username enumeration. // Default: "Webauthn\\SimpleFakeCredentialGenerator"
+ *     clock?: scalar|null|Param, // PSR-20 Clock service. // Default: "webauthn.clock.default"
+ *     options_storage?: scalar|null|Param, // Service responsible of the options/user entity storage during the ceremony // Default: "Webauthn\\Bundle\\Security\\Storage\\SessionStorage"
+ *     event_dispatcher?: scalar|null|Param, // PSR-14 Event Dispatcher service. // Default: "Psr\\EventDispatcher\\EventDispatcherInterface"
+ *     http_client?: scalar|null|Param, // A Symfony HTTP client. // Default: "webauthn.http_client.default"
+ *     logger?: scalar|null|Param, // A PSR-3 logger to receive logs during the processes // Default: "webauthn.logger.default"
+ *     credential_repository?: scalar|null|Param, // This repository is responsible of the credential storage // Default: "Webauthn\\Bundle\\Repository\\DummyPublicKeyCredentialSourceRepository"
+ *     user_repository?: scalar|null|Param, // This repository is responsible of the user storage // Default: "Webauthn\\Bundle\\Repository\\DummyPublicKeyCredentialUserEntityRepository"
+ *     allowed_origins?: array<string, scalar|null|Param>,
+ *     allow_subdomains?: bool|Param, // Default: false
+ *     secured_rp_ids?: array<string, scalar|null|Param>,
+ *     counter_checker?: scalar|null|Param, // This service will check if the counter is valid. By default it throws an exception (recommended). // Default: "Webauthn\\Counter\\ThrowExceptionIfInvalid"
+ *     top_origin_validator?: scalar|null|Param, // For cross origin (e.g. iframe), this service will be in charge of verifying the top origin. // Default: null
  *     creation_profiles?: array<string, array{ // Default: []
  *         rp: array{
- *             id?: scalar|null, // Default: null
- *             name: scalar|null,
- *             icon?: scalar|null, // Deprecated: The child node "icon" at path "webauthn.creation_profiles..rp.icon" is deprecated and has no effect. // Default: null
+ *             id?: scalar|null|Param, // Default: null
+ *             name: scalar|null|Param,
+ *             icon?: scalar|null|Param, // Deprecated: The child node "icon" at path "webauthn.creation_profiles..rp.icon" is deprecated and has no effect. // Default: null
  *         },
- *         challenge_length?: int, // Default: 32
- *         timeout?: int, // Default: null
+ *         challenge_length?: int|Param, // Default: 32
+ *         timeout?: int|Param, // Default: null
  *         authenticator_selection_criteria?: array{
- *             authenticator_attachment?: scalar|null, // Default: null
- *             require_resident_key?: bool, // Default: false
- *             user_verification?: scalar|null, // Default: "preferred"
- *             resident_key?: scalar|null, // Default: "preferred"
+ *             authenticator_attachment?: scalar|null|Param, // Default: null
+ *             require_resident_key?: bool|Param, // Default: false
+ *             user_verification?: scalar|null|Param, // Default: "preferred"
+ *             resident_key?: scalar|null|Param, // Default: "preferred"
  *         },
- *         extensions?: array<string, scalar|null>,
- *         public_key_credential_parameters?: list<int>,
- *         attestation_conveyance?: scalar|null, // Default: "none"
+ *         extensions?: array<string, scalar|null|Param>,
+ *         public_key_credential_parameters?: list<int|Param>,
+ *         attestation_conveyance?: scalar|null|Param, // Default: "none"
  *     }>,
  *     request_profiles?: array<string, array{ // Default: []
- *         rp_id?: scalar|null, // Default: null
- *         challenge_length?: int, // Default: 32
- *         timeout?: int, // Default: null
- *         user_verification?: scalar|null, // Default: "preferred"
- *         extensions?: array<string, scalar|null>,
+ *         rp_id?: scalar|null|Param, // Default: null
+ *         challenge_length?: int|Param, // Default: 32
+ *         timeout?: int|Param, // Default: null
+ *         user_verification?: scalar|null|Param, // Default: "preferred"
+ *         extensions?: array<string, scalar|null|Param>,
  *     }>,
  *     metadata?: bool|array{ // Enable the support of the Metadata Statements. Please read the documentation for this feature.
- *         enabled?: bool, // Default: false
- *         mds_repository: scalar|null, // The Metadata Statement repository.
- *         status_report_repository: scalar|null, // The Status Report repository.
- *         certificate_chain_checker?: scalar|null, // A Certificate Chain checker. // Default: "Webauthn\\MetadataService\\CertificateChain\\PhpCertificateChainValidator"
+ *         enabled?: bool|Param, // Default: false
+ *         mds_repository: scalar|null|Param, // The Metadata Statement repository.
+ *         status_report_repository: scalar|null|Param, // The Status Report repository.
+ *         certificate_chain_checker?: scalar|null|Param, // A Certificate Chain checker. // Default: "Webauthn\\MetadataService\\CertificateChain\\PhpCertificateChainValidator"
  *     },
  *     controllers?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *         creation?: array<string, array{ // Default: []
- *             options_method?: scalar|null, // Default: "POST"
- *             options_path: scalar|null,
- *             result_method?: scalar|null, // Default: "POST"
- *             result_path?: scalar|null, // Default: null
- *             host?: scalar|null, // Default: null
- *             profile?: scalar|null, // Default: "default"
- *             options_builder?: scalar|null, // When set, corresponds to the ID of the Public Key Credential Creation Builder. The profile-based ebuilder is ignored. // Default: null
- *             user_entity_guesser: scalar|null,
- *             hide_existing_credentials?: scalar|null, // In order to prevent username enumeration, the existing credentials can be hidden. This is highly recommended when the attestation ceremony is performed by anonymous users. // Default: false
- *             options_storage?: scalar|null, // Deprecated: The child node "options_storage" at path "webauthn.controllers.creation..options_storage" is deprecated. Please use the root option "options_storage" instead. // Service responsible of the options/user entity storage during the ceremony // Default: null
- *             success_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Service\\DefaultSuccessHandler"
- *             failure_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Service\\DefaultFailureHandler"
- *             options_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultCreationOptionsHandler"
- *             allowed_origins?: array<string, scalar|null>,
- *             allow_subdomains?: bool, // Default: false
- *             secured_rp_ids?: array<string, scalar|null>,
+ *             options_method?: scalar|null|Param, // Default: "POST"
+ *             options_path: scalar|null|Param,
+ *             result_method?: scalar|null|Param, // Default: "POST"
+ *             result_path?: scalar|null|Param, // Default: null
+ *             host?: scalar|null|Param, // Default: null
+ *             profile?: scalar|null|Param, // Default: "default"
+ *             options_builder?: scalar|null|Param, // When set, corresponds to the ID of the Public Key Credential Creation Builder. The profile-based ebuilder is ignored. // Default: null
+ *             user_entity_guesser: scalar|null|Param,
+ *             hide_existing_credentials?: scalar|null|Param, // In order to prevent username enumeration, the existing credentials can be hidden. This is highly recommended when the attestation ceremony is performed by anonymous users. // Default: false
+ *             options_storage?: scalar|null|Param, // Deprecated: The child node "options_storage" at path "webauthn.controllers.creation..options_storage" is deprecated. Please use the root option "options_storage" instead. // Service responsible of the options/user entity storage during the ceremony // Default: null
+ *             success_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Service\\DefaultSuccessHandler"
+ *             failure_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Service\\DefaultFailureHandler"
+ *             options_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultCreationOptionsHandler"
+ *             allowed_origins?: array<string, scalar|null|Param>,
+ *             allow_subdomains?: bool|Param, // Default: false
+ *             secured_rp_ids?: array<string, scalar|null|Param>,
  *         }>,
  *         request?: array<string, array{ // Default: []
- *             options_method?: scalar|null, // Default: "POST"
- *             options_path: scalar|null,
- *             result_method?: scalar|null, // Default: "POST"
- *             result_path?: scalar|null, // Default: null
- *             host?: scalar|null, // Default: null
- *             profile?: scalar|null, // Default: "default"
- *             options_builder?: scalar|null, // When set, corresponds to the ID of the Public Key Credential Creation Builder. The profile-based ebuilder is ignored. // Default: null
- *             options_storage?: scalar|null, // Deprecated: The child node "options_storage" at path "webauthn.controllers.request..options_storage" is deprecated. Please use the root option "options_storage" instead. // Service responsible of the options/user entity storage during the ceremony // Default: null
- *             success_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Service\\DefaultSuccessHandler"
- *             failure_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Service\\DefaultFailureHandler"
- *             options_handler?: scalar|null, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultRequestOptionsHandler"
- *             allowed_origins?: array<string, scalar|null>,
- *             allow_subdomains?: bool, // Default: false
- *             secured_rp_ids?: array<string, scalar|null>,
+ *             options_method?: scalar|null|Param, // Default: "POST"
+ *             options_path: scalar|null|Param,
+ *             result_method?: scalar|null|Param, // Default: "POST"
+ *             result_path?: scalar|null|Param, // Default: null
+ *             host?: scalar|null|Param, // Default: null
+ *             profile?: scalar|null|Param, // Default: "default"
+ *             options_builder?: scalar|null|Param, // When set, corresponds to the ID of the Public Key Credential Creation Builder. The profile-based ebuilder is ignored. // Default: null
+ *             options_storage?: scalar|null|Param, // Deprecated: The child node "options_storage" at path "webauthn.controllers.request..options_storage" is deprecated. Please use the root option "options_storage" instead. // Service responsible of the options/user entity storage during the ceremony // Default: null
+ *             success_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Service\\DefaultSuccessHandler"
+ *             failure_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Service\\DefaultFailureHandler"
+ *             options_handler?: scalar|null|Param, // Default: "Webauthn\\Bundle\\Security\\Handler\\DefaultRequestOptionsHandler"
+ *             allowed_origins?: array<string, scalar|null|Param>,
+ *             allow_subdomains?: bool|Param, // Default: false
+ *             secured_rp_ids?: array<string, scalar|null|Param>,
  *         }>,
  *     },
  * }
  * @psalm-type NbgrpOneloginSamlConfig = array{ // nb:group OneLogin PHP Symfony Bundle configuration
  *     onelogin_settings?: array<string, array{ // Default: []
- *         baseurl?: scalar|null, // Default: "<request_scheme_and_host>/saml/"
- *         strict?: bool,
- *         debug?: bool,
+ *         baseurl?: scalar|null|Param, // Default: "<request_scheme_and_host>/saml/"
+ *         strict?: bool|Param,
+ *         debug?: bool|Param,
  *         idp: array{
- *             entityId: scalar|null,
+ *             entityId: scalar|null|Param,
  *             singleSignOnService: array{
- *                 url: scalar|null,
- *                 binding?: scalar|null,
+ *                 url: scalar|null|Param,
+ *                 binding?: scalar|null|Param,
  *             },
  *             singleLogoutService?: array{
- *                 url?: scalar|null,
- *                 responseUrl?: scalar|null,
- *                 binding?: scalar|null,
+ *                 url?: scalar|null|Param,
+ *                 responseUrl?: scalar|null|Param,
+ *                 binding?: scalar|null|Param,
  *             },
- *             x509cert?: scalar|null,
- *             certFingerprint?: scalar|null,
- *             certFingerprintAlgorithm?: "sha1"|"sha256"|"sha384"|"sha512",
+ *             x509cert?: scalar|null|Param,
+ *             certFingerprint?: scalar|null|Param,
+ *             certFingerprintAlgorithm?: "sha1"|"sha256"|"sha384"|"sha512"|Param,
  *             x509certMulti?: array{
- *                 signing?: list<scalar|null>,
- *                 encryption?: list<scalar|null>,
+ *                 signing?: list<scalar|null|Param>,
+ *                 encryption?: list<scalar|null|Param>,
  *             },
  *         },
  *         sp?: array{
- *             entityId?: scalar|null, // Default: "<request_scheme_and_host>/saml/metadata"
+ *             entityId?: scalar|null|Param, // Default: "<request_scheme_and_host>/saml/metadata"
  *             assertionConsumerService?: array{
- *                 url?: scalar|null, // Default: "<request_scheme_and_host>/saml/acs"
- *                 binding?: scalar|null,
+ *                 url?: scalar|null|Param, // Default: "<request_scheme_and_host>/saml/acs"
+ *                 binding?: scalar|null|Param,
  *             },
  *             attributeConsumingService?: array{
- *                 serviceName?: scalar|null,
- *                 serviceDescription?: scalar|null,
+ *                 serviceName?: scalar|null|Param,
+ *                 serviceDescription?: scalar|null|Param,
  *                 requestedAttributes?: list<array{ // Default: []
- *                     name?: scalar|null,
- *                     isRequired?: bool, // Default: false
- *                     nameFormat?: scalar|null,
- *                     friendlyName?: scalar|null,
+ *                     name?: scalar|null|Param,
+ *                     isRequired?: bool|Param, // Default: false
+ *                     nameFormat?: scalar|null|Param,
+ *                     friendlyName?: scalar|null|Param,
  *                     attributeValue?: array<mixed>,
  *                 }>,
  *             },
  *             singleLogoutService?: array{
- *                 url?: scalar|null, // Default: "<request_scheme_and_host>/saml/logout"
- *                 binding?: scalar|null,
+ *                 url?: scalar|null|Param, // Default: "<request_scheme_and_host>/saml/logout"
+ *                 binding?: scalar|null|Param,
  *             },
- *             NameIDFormat?: scalar|null,
- *             x509cert?: scalar|null,
- *             privateKey?: scalar|null,
- *             x509certNew?: scalar|null,
+ *             NameIDFormat?: scalar|null|Param,
+ *             x509cert?: scalar|null|Param,
+ *             privateKey?: scalar|null|Param,
+ *             x509certNew?: scalar|null|Param,
  *         },
  *         compress?: array{
- *             requests?: bool,
- *             responses?: bool,
+ *             requests?: bool|Param,
+ *             responses?: bool|Param,
  *         },
  *         security?: array{
- *             nameIdEncrypted?: bool,
- *             authnRequestsSigned?: bool,
- *             logoutRequestSigned?: bool,
- *             logoutResponseSigned?: bool,
- *             signMetadata?: bool,
- *             wantMessagesSigned?: bool,
- *             wantAssertionsEncrypted?: bool,
- *             wantAssertionsSigned?: bool,
- *             wantNameId?: bool,
- *             wantNameIdEncrypted?: bool,
+ *             nameIdEncrypted?: bool|Param,
+ *             authnRequestsSigned?: bool|Param,
+ *             logoutRequestSigned?: bool|Param,
+ *             logoutResponseSigned?: bool|Param,
+ *             signMetadata?: bool|Param,
+ *             wantMessagesSigned?: bool|Param,
+ *             wantAssertionsEncrypted?: bool|Param,
+ *             wantAssertionsSigned?: bool|Param,
+ *             wantNameId?: bool|Param,
+ *             wantNameIdEncrypted?: bool|Param,
  *             requestedAuthnContext?: mixed,
- *             requestedAuthnContextComparison?: "exact"|"minimum"|"maximum"|"better",
- *             wantXMLValidation?: bool,
- *             relaxDestinationValidation?: bool,
- *             destinationStrictlyMatches?: bool,
- *             allowRepeatAttributeName?: bool,
- *             rejectUnsolicitedResponsesWithInResponseTo?: bool,
- *             signatureAlgorithm?: "http://www.w3.org/2000/09/xmldsig#rsa-sha1"|"http://www.w3.org/2000/09/xmldsig#dsa-sha1"|"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"|"http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"|"http://www.w3.org/2001/04/xmldsig-more#rsa-sha512",
- *             digestAlgorithm?: "http://www.w3.org/2000/09/xmldsig#sha1"|"http://www.w3.org/2001/04/xmlenc#sha256"|"http://www.w3.org/2001/04/xmldsig-more#sha384"|"http://www.w3.org/2001/04/xmlenc#sha512",
- *             encryption_algorithm?: "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"|"http://www.w3.org/2001/04/xmlenc#aes128-cbc"|"http://www.w3.org/2001/04/xmlenc#aes192-cbc"|"http://www.w3.org/2001/04/xmlenc#aes256-cbc"|"http://www.w3.org/2009/xmlenc11#aes128-gcm"|"http://www.w3.org/2009/xmlenc11#aes192-gcm"|"http://www.w3.org/2009/xmlenc11#aes256-gcm",
- *             lowercaseUrlencoding?: bool,
+ *             requestedAuthnContextComparison?: "exact"|"minimum"|"maximum"|"better"|Param,
+ *             wantXMLValidation?: bool|Param,
+ *             relaxDestinationValidation?: bool|Param,
+ *             destinationStrictlyMatches?: bool|Param,
+ *             allowRepeatAttributeName?: bool|Param,
+ *             rejectUnsolicitedResponsesWithInResponseTo?: bool|Param,
+ *             signatureAlgorithm?: "http://www.w3.org/2000/09/xmldsig#rsa-sha1"|"http://www.w3.org/2000/09/xmldsig#dsa-sha1"|"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"|"http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"|"http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"|Param,
+ *             digestAlgorithm?: "http://www.w3.org/2000/09/xmldsig#sha1"|"http://www.w3.org/2001/04/xmlenc#sha256"|"http://www.w3.org/2001/04/xmldsig-more#sha384"|"http://www.w3.org/2001/04/xmlenc#sha512"|Param,
+ *             encryption_algorithm?: "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"|"http://www.w3.org/2001/04/xmlenc#aes128-cbc"|"http://www.w3.org/2001/04/xmlenc#aes192-cbc"|"http://www.w3.org/2001/04/xmlenc#aes256-cbc"|"http://www.w3.org/2009/xmlenc11#aes128-gcm"|"http://www.w3.org/2009/xmlenc11#aes192-gcm"|"http://www.w3.org/2009/xmlenc11#aes256-gcm"|Param,
+ *             lowercaseUrlencoding?: bool|Param,
  *         },
  *         contactPerson?: array{
  *             technical?: array{
- *                 givenName: scalar|null,
- *                 emailAddress: scalar|null,
+ *                 givenName: scalar|null|Param,
+ *                 emailAddress: scalar|null|Param,
  *             },
  *             support?: array{
- *                 givenName: scalar|null,
- *                 emailAddress: scalar|null,
+ *                 givenName: scalar|null|Param,
+ *                 emailAddress: scalar|null|Param,
  *             },
  *             administrative?: array{
- *                 givenName: scalar|null,
- *                 emailAddress: scalar|null,
+ *                 givenName: scalar|null|Param,
+ *                 emailAddress: scalar|null|Param,
  *             },
  *             billing?: array{
- *                 givenName: scalar|null,
- *                 emailAddress: scalar|null,
+ *                 givenName: scalar|null|Param,
+ *                 emailAddress: scalar|null|Param,
  *             },
  *             other?: array{
- *                 givenName: scalar|null,
- *                 emailAddress: scalar|null,
+ *                 givenName: scalar|null|Param,
+ *                 emailAddress: scalar|null|Param,
  *             },
  *         },
  *         organization?: list<array{ // Default: []
- *             name: scalar|null,
- *             displayname: scalar|null,
- *             url: scalar|null,
+ *             name: scalar|null|Param,
+ *             displayname: scalar|null|Param,
+ *             url: scalar|null|Param,
  *         }>,
  *     }>,
- *     use_proxy_vars?: bool, // Default: false
- *     idp_parameter_name?: scalar|null, // Default: "idp"
- *     entity_manager_name?: scalar|null,
+ *     use_proxy_vars?: bool|Param, // Default: false
+ *     idp_parameter_name?: scalar|null|Param, // Default: "idp"
+ *     entity_manager_name?: scalar|null|Param,
  *     authn_request?: array{
- *         parameters?: list<scalar|null>,
- *         forceAuthn?: bool, // Default: false
- *         isPassive?: bool, // Default: false
- *         setNameIdPolicy?: bool, // Default: true
- *         nameIdValueReq?: scalar|null, // Default: null
+ *         parameters?: list<scalar|null|Param>,
+ *         forceAuthn?: bool|Param, // Default: false
+ *         isPassive?: bool|Param, // Default: false
+ *         setNameIdPolicy?: bool|Param, // Default: true
+ *         nameIdValueReq?: scalar|null|Param, // Default: null
  *     },
  * }
  * @psalm-type StimulusConfig = array{
- *     controller_paths?: list<scalar|null>,
- *     controllers_json?: scalar|null, // Default: "%kernel.project_dir%/assets/controllers.json"
+ *     controller_paths?: list<scalar|null|Param>,
+ *     controllers_json?: scalar|null|Param, // Default: "%kernel.project_dir%/assets/controllers.json"
  * }
  * @psalm-type UxTranslatorConfig = array{
- *     dump_directory?: scalar|null, // Default: "%kernel.project_dir%/var/translations"
+ *     dump_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/var/translations"
  *     domains?: string|array{ // List of domains to include/exclude from the generated translations. Prefix with a `!` to exclude a domain.
- *         type?: scalar|null,
- *         elements?: list<scalar|null>,
+ *         type?: scalar|null|Param,
+ *         elements?: list<scalar|null|Param>,
  *     },
  * }
  * @psalm-type DompdfFontLoaderConfig = array{
  *     autodiscovery?: bool|array{
- *         paths?: list<scalar|null>,
- *         exclude_patterns?: list<scalar|null>,
- *         file_pattern?: scalar|null, // Default: "/\\.(ttf)$/"
- *         enabled?: bool, // Default: true
+ *         paths?: list<scalar|null|Param>,
+ *         exclude_patterns?: list<scalar|null|Param>,
+ *         file_pattern?: scalar|null|Param, // Default: "/\\.(ttf)$/"
+ *         enabled?: bool|Param, // Default: true
  *     },
- *     auto_install?: bool, // Default: false
+ *     auto_install?: bool|Param, // Default: false
  *     fonts?: list<array{ // Default: []
- *         normal: scalar|null,
- *         bold?: scalar|null,
- *         italic?: scalar|null,
- *         bold_italic?: scalar|null,
+ *         normal: scalar|null|Param,
+ *         bold?: scalar|null|Param,
+ *         italic?: scalar|null|Param,
+ *         bold_italic?: scalar|null|Param,
  *     }>,
  * }
  * @psalm-type KnpuOauth2ClientConfig = array{
- *     http_client?: scalar|null, // Service id of HTTP client to use (must implement GuzzleHttp\ClientInterface) // Default: null
+ *     http_client?: scalar|null|Param, // Service id of HTTP client to use (must implement GuzzleHttp\ClientInterface) // Default: null
  *     http_client_options?: array{
- *         timeout?: int,
- *         proxy?: scalar|null,
- *         verify?: bool, // Use only with proxy option set
+ *         timeout?: int|Param,
+ *         proxy?: scalar|null|Param,
+ *         verify?: bool|Param, // Use only with proxy option set
  *     },
  *     clients?: array<string, array<string, mixed>>,
  * }
  * @psalm-type NelmioCorsConfig = array{
  *     defaults?: array{
- *         allow_credentials?: bool, // Default: false
- *         allow_origin?: list<scalar|null>,
- *         allow_headers?: list<scalar|null>,
- *         allow_methods?: list<scalar|null>,
- *         allow_private_network?: bool, // Default: false
- *         expose_headers?: list<scalar|null>,
- *         max_age?: scalar|null, // Default: 0
- *         hosts?: list<scalar|null>,
- *         origin_regex?: bool, // Default: false
- *         forced_allow_origin_value?: scalar|null, // Default: null
- *         skip_same_as_origin?: bool, // Default: true
+ *         allow_credentials?: bool|Param, // Default: false
+ *         allow_origin?: list<scalar|null|Param>,
+ *         allow_headers?: list<scalar|null|Param>,
+ *         allow_methods?: list<scalar|null|Param>,
+ *         allow_private_network?: bool|Param, // Default: false
+ *         expose_headers?: list<scalar|null|Param>,
+ *         max_age?: scalar|null|Param, // Default: 0
+ *         hosts?: list<scalar|null|Param>,
+ *         origin_regex?: bool|Param, // Default: false
+ *         forced_allow_origin_value?: scalar|null|Param, // Default: null
+ *         skip_same_as_origin?: bool|Param, // Default: true
  *     },
  *     paths?: array<string, array{ // Default: []
- *         allow_credentials?: bool,
- *         allow_origin?: list<scalar|null>,
- *         allow_headers?: list<scalar|null>,
- *         allow_methods?: list<scalar|null>,
- *         allow_private_network?: bool,
- *         expose_headers?: list<scalar|null>,
- *         max_age?: scalar|null, // Default: 0
- *         hosts?: list<scalar|null>,
- *         origin_regex?: bool,
- *         forced_allow_origin_value?: scalar|null, // Default: null
- *         skip_same_as_origin?: bool,
+ *         allow_credentials?: bool|Param,
+ *         allow_origin?: list<scalar|null|Param>,
+ *         allow_headers?: list<scalar|null|Param>,
+ *         allow_methods?: list<scalar|null|Param>,
+ *         allow_private_network?: bool|Param,
+ *         expose_headers?: list<scalar|null|Param>,
+ *         max_age?: scalar|null|Param, // Default: 0
+ *         hosts?: list<scalar|null|Param>,
+ *         origin_regex?: bool|Param,
+ *         forced_allow_origin_value?: scalar|null|Param, // Default: null
+ *         skip_same_as_origin?: bool|Param,
  *     }>,
  * }
  * @psalm-type JbtronicsSettingsConfig = array{
- *     search_paths?: list<scalar|null>,
- *     proxy_dir?: scalar|null, // Default: "%kernel.cache_dir%/jbtronics_settings/proxies"
- *     proxy_namespace?: scalar|null, // Default: "Jbtronics\\SettingsBundle\\Proxies"
- *     default_storage_adapter?: scalar|null, // Default: null
- *     save_after_migration?: bool, // Default: true
+ *     search_paths?: list<scalar|null|Param>,
+ *     proxy_dir?: scalar|null|Param, // Default: "%kernel.cache_dir%/jbtronics_settings/proxies"
+ *     proxy_namespace?: scalar|null|Param, // Default: "Jbtronics\\SettingsBundle\\Proxies"
+ *     default_storage_adapter?: scalar|null|Param, // Default: null
+ *     save_after_migration?: bool|Param, // Default: true
  *     file_storage?: array{
- *         storage_directory?: scalar|null, // Default: "%kernel.project_dir%/var/jbtronics_settings/"
- *         default_filename?: scalar|null, // Default: "settings"
+ *         storage_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/var/jbtronics_settings/"
+ *         default_filename?: scalar|null|Param, // Default: "settings"
  *     },
  *     orm_storage?: array{
- *         default_entity_class?: scalar|null, // Default: null
- *         prefetch_all?: bool, // Default: true
+ *         default_entity_class?: scalar|null|Param, // Default: null
+ *         prefetch_all?: bool|Param, // Default: true
  *     },
  *     cache?: array{
- *         service?: scalar|null, // Default: "cache.app.taggable"
- *         default_cacheable?: bool, // Default: false
- *         ttl?: int, // Default: 0
- *         invalidate_on_env_change?: bool, // Default: true
+ *         service?: scalar|null|Param, // Default: "cache.app.taggable"
+ *         default_cacheable?: bool|Param, // Default: false
+ *         ttl?: int|Param, // Default: 0
+ *         invalidate_on_env_change?: bool|Param, // Default: true
  *     },
  * }
  * @psalm-type JbtronicsTranslationEditorConfig = array{
- *     translations_path?: scalar|null, // Default: "%translator.default_path%"
- *     format?: scalar|null, // Default: "xlf"
- *     xliff_version?: scalar|null, // Default: "2.0"
- *     use_intl_icu_format?: bool, // Default: false
- *     writer_options?: list<scalar|null>,
+ *     translations_path?: scalar|null|Param, // Default: "%translator.default_path%"
+ *     format?: scalar|null|Param, // Default: "xlf"
+ *     xliff_version?: scalar|null|Param, // Default: "2.0"
+ *     use_intl_icu_format?: bool|Param, // Default: false
+ *     writer_options?: list<scalar|null|Param>,
  * }
  * @psalm-type ApiPlatformConfig = array{
- *     title?: scalar|null, // The title of the API. // Default: ""
- *     description?: scalar|null, // The description of the API. // Default: ""
- *     version?: scalar|null, // The version of the API. // Default: "0.0.0"
- *     show_webby?: bool, // If true, show Webby on the documentation page // Default: true
- *     use_symfony_listeners?: bool, // Uses Symfony event listeners instead of the ApiPlatform\Symfony\Controller\MainController. // Default: false
- *     name_converter?: scalar|null, // Specify a name converter to use. // Default: null
- *     asset_package?: scalar|null, // Specify an asset package name to use. // Default: null
- *     path_segment_name_generator?: scalar|null, // Specify a path name generator to use. // Default: "api_platform.metadata.path_segment_name_generator.underscore"
- *     inflector?: scalar|null, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
+ *     title?: scalar|null|Param, // The title of the API. // Default: ""
+ *     description?: scalar|null|Param, // The description of the API. // Default: ""
+ *     version?: scalar|null|Param, // The version of the API. // Default: "0.0.0"
+ *     show_webby?: bool|Param, // If true, show Webby on the documentation page // Default: true
+ *     use_symfony_listeners?: bool|Param, // Uses Symfony event listeners instead of the ApiPlatform\Symfony\Controller\MainController. // Default: false
+ *     name_converter?: scalar|null|Param, // Specify a name converter to use. // Default: null
+ *     asset_package?: scalar|null|Param, // Specify an asset package name to use. // Default: null
+ *     path_segment_name_generator?: scalar|null|Param, // Specify a path name generator to use. // Default: "api_platform.metadata.path_segment_name_generator.underscore"
+ *     inflector?: scalar|null|Param, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
  *     validator?: array{
  *         serialize_payload_fields?: mixed, // Set to null to serialize all payload fields when a validation error is thrown, or set the fields you want to include explicitly. // Default: []
- *         query_parameter_validation?: bool, // Deprecated: Will be removed in API Platform 5.0. // Default: true
+ *         query_parameter_validation?: bool|Param, // Deprecated: Will be removed in API Platform 5.0. // Default: true
  *     },
  *     eager_loading?: bool|array{
- *         enabled?: bool, // Default: true
- *         fetch_partial?: bool, // Fetch only partial data according to serialization groups. If enabled, Doctrine ORM entities will not work as expected if any of the other fields are used. // Default: false
- *         max_joins?: int, // Max number of joined relations before EagerLoading throws a RuntimeException // Default: 30
- *         force_eager?: bool, // Force join on every relation. If disabled, it will only join relations having the EAGER fetch mode. // Default: true
+ *         enabled?: bool|Param, // Default: true
+ *         fetch_partial?: bool|Param, // Fetch only partial data according to serialization groups. If enabled, Doctrine ORM entities will not work as expected if any of the other fields are used. // Default: false
+ *         max_joins?: int|Param, // Max number of joined relations before EagerLoading throws a RuntimeException // Default: 30
+ *         force_eager?: bool|Param, // Force join on every relation. If disabled, it will only join relations having the EAGER fetch mode. // Default: true
  *     },
- *     handle_symfony_errors?: bool, // Allows to handle symfony exceptions. // Default: false
- *     enable_swagger?: bool, // Enable the Swagger documentation and export. // Default: true
- *     enable_json_streamer?: bool, // Enable json streamer. // Default: false
- *     enable_swagger_ui?: bool, // Enable Swagger UI // Default: true
- *     enable_re_doc?: bool, // Enable ReDoc // Default: true
- *     enable_entrypoint?: bool, // Enable the entrypoint // Default: true
- *     enable_docs?: bool, // Enable the docs // Default: true
- *     enable_profiler?: bool, // Enable the data collector and the WebProfilerBundle integration. // Default: true
- *     enable_phpdoc_parser?: bool, // Enable resource metadata collector using PHPStan PhpDocParser. // Default: true
- *     enable_link_security?: bool, // Enable security for Links (sub resources) // Default: false
+ *     handle_symfony_errors?: bool|Param, // Allows to handle symfony exceptions. // Default: false
+ *     enable_swagger?: bool|Param, // Enable the Swagger documentation and export. // Default: true
+ *     enable_json_streamer?: bool|Param, // Enable json streamer. // Default: false
+ *     enable_swagger_ui?: bool|Param, // Enable Swagger UI // Default: true
+ *     enable_re_doc?: bool|Param, // Enable ReDoc // Default: true
+ *     enable_entrypoint?: bool|Param, // Enable the entrypoint // Default: true
+ *     enable_docs?: bool|Param, // Enable the docs // Default: true
+ *     enable_profiler?: bool|Param, // Enable the data collector and the WebProfilerBundle integration. // Default: true
+ *     enable_phpdoc_parser?: bool|Param, // Enable resource metadata collector using PHPStan PhpDocParser. // Default: true
+ *     enable_link_security?: bool|Param, // Enable security for Links (sub resources) // Default: false
  *     collection?: array{
- *         exists_parameter_name?: scalar|null, // The name of the query parameter to filter on nullable field values. // Default: "exists"
- *         order?: scalar|null, // The default order of results. // Default: "ASC"
- *         order_parameter_name?: scalar|null, // The name of the query parameter to order results. // Default: "order"
- *         order_nulls_comparison?: "nulls_smallest"|"nulls_largest"|"nulls_always_first"|"nulls_always_last"|null, // The nulls comparison strategy. // Default: null
+ *         exists_parameter_name?: scalar|null|Param, // The name of the query parameter to filter on nullable field values. // Default: "exists"
+ *         order?: scalar|null|Param, // The default order of results. // Default: "ASC"
+ *         order_parameter_name?: scalar|null|Param, // The name of the query parameter to order results. // Default: "order"
+ *         order_nulls_comparison?: "nulls_smallest"|"nulls_largest"|"nulls_always_first"|"nulls_always_last"|null|Param, // The nulls comparison strategy. // Default: null
  *         pagination?: bool|array{
- *             enabled?: bool, // Default: true
- *             page_parameter_name?: scalar|null, // The default name of the parameter handling the page number. // Default: "page"
- *             enabled_parameter_name?: scalar|null, // The name of the query parameter to enable or disable pagination. // Default: "pagination"
- *             items_per_page_parameter_name?: scalar|null, // The name of the query parameter to set the number of items per page. // Default: "itemsPerPage"
- *             partial_parameter_name?: scalar|null, // The name of the query parameter to enable or disable partial pagination. // Default: "partial"
+ *             enabled?: bool|Param, // Default: true
+ *             page_parameter_name?: scalar|null|Param, // The default name of the parameter handling the page number. // Default: "page"
+ *             enabled_parameter_name?: scalar|null|Param, // The name of the query parameter to enable or disable pagination. // Default: "pagination"
+ *             items_per_page_parameter_name?: scalar|null|Param, // The name of the query parameter to set the number of items per page. // Default: "itemsPerPage"
+ *             partial_parameter_name?: scalar|null|Param, // The name of the query parameter to enable or disable partial pagination. // Default: "partial"
  *         },
  *     },
  *     mapping?: array{
- *         imports?: list<scalar|null>,
- *         paths?: list<scalar|null>,
+ *         imports?: list<scalar|null|Param>,
+ *         paths?: list<scalar|null|Param>,
  *     },
- *     resource_class_directories?: list<scalar|null>,
+ *     resource_class_directories?: list<scalar|null|Param>,
  *     serializer?: array{
- *         hydra_prefix?: bool, // Use the "hydra:" prefix. // Default: false
+ *         hydra_prefix?: bool|Param, // Use the "hydra:" prefix. // Default: false
  *     },
  *     doctrine?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     doctrine_mongodb_odm?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     oauth?: bool|array{
- *         enabled?: bool, // Default: false
- *         clientId?: scalar|null, // The oauth client id. // Default: ""
- *         clientSecret?: scalar|null, // The OAuth client secret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only. Enable "oauth.pkce" instead // Default: ""
- *         pkce?: bool, // Enable the oauth PKCE. // Default: false
- *         type?: scalar|null, // The oauth type. // Default: "oauth2"
- *         flow?: scalar|null, // The oauth flow grant type. // Default: "application"
- *         tokenUrl?: scalar|null, // The oauth token url. // Default: ""
- *         authorizationUrl?: scalar|null, // The oauth authentication url. // Default: ""
- *         refreshUrl?: scalar|null, // The oauth refresh url. // Default: ""
- *         scopes?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         clientId?: scalar|null|Param, // The oauth client id. // Default: ""
+ *         clientSecret?: scalar|null|Param, // The OAuth client secret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only. Enable "oauth.pkce" instead // Default: ""
+ *         pkce?: bool|Param, // Enable the oauth PKCE. // Default: false
+ *         type?: scalar|null|Param, // The oauth type. // Default: "oauth2"
+ *         flow?: scalar|null|Param, // The oauth flow grant type. // Default: "application"
+ *         tokenUrl?: scalar|null|Param, // The oauth token url. // Default: ""
+ *         authorizationUrl?: scalar|null|Param, // The oauth authentication url. // Default: ""
+ *         refreshUrl?: scalar|null|Param, // The oauth refresh url. // Default: ""
+ *         scopes?: list<scalar|null|Param>,
  *     },
  *     graphql?: bool|array{
- *         enabled?: bool, // Default: false
- *         default_ide?: scalar|null, // Default: "graphiql"
+ *         enabled?: bool|Param, // Default: false
+ *         default_ide?: scalar|null|Param, // Default: "graphiql"
  *         graphiql?: bool|array{
- *             enabled?: bool, // Default: false
+ *             enabled?: bool|Param, // Default: false
  *         },
  *         introspection?: bool|array{
- *             enabled?: bool, // Default: true
+ *             enabled?: bool|Param, // Default: true
  *         },
- *         max_query_depth?: int, // Default: 20
+ *         max_query_depth?: int|Param, // Default: 20
  *         graphql_playground?: array<mixed>,
- *         max_query_complexity?: int, // Default: 500
- *         nesting_separator?: scalar|null, // The separator to use to filter nested fields. // Default: "_"
+ *         max_query_complexity?: int|Param, // Default: 500
+ *         nesting_separator?: scalar|null|Param, // The separator to use to filter nested fields. // Default: "_"
  *         collection?: array{
  *             pagination?: bool|array{
- *                 enabled?: bool, // Default: true
+ *                 enabled?: bool|Param, // Default: true
  *             },
  *         },
  *     },
  *     swagger?: array{
- *         persist_authorization?: bool, // Persist the SwaggerUI Authorization in the localStorage. // Default: false
- *         versions?: list<scalar|null>,
+ *         persist_authorization?: bool|Param, // Persist the SwaggerUI Authorization in the localStorage. // Default: false
+ *         versions?: list<scalar|null|Param>,
  *         api_keys?: array<string, array{ // Default: []
- *             name?: scalar|null, // The name of the header or query parameter containing the api key.
- *             type?: "query"|"header", // Whether the api key should be a query parameter or a header.
+ *             name?: scalar|null|Param, // The name of the header or query parameter containing the api key.
+ *             type?: "query"|"header"|Param, // Whether the api key should be a query parameter or a header.
  *         }>,
  *         http_auth?: array<string, array{ // Default: []
- *             scheme?: scalar|null, // The OpenAPI HTTP auth scheme, for example "bearer"
- *             bearerFormat?: scalar|null, // The OpenAPI HTTP bearer format
+ *             scheme?: scalar|null|Param, // The OpenAPI HTTP auth scheme, for example "bearer"
+ *             bearerFormat?: scalar|null|Param, // The OpenAPI HTTP bearer format
  *         }>,
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
  *     },
  *     http_cache?: array{
- *         public?: bool|null, // To make all responses public by default. // Default: null
+ *         public?: bool|null|Param, // To make all responses public by default. // Default: null
  *         invalidation?: bool|array{ // Enable the tags-based cache invalidation system.
- *             enabled?: bool, // Default: false
- *             varnish_urls?: list<scalar|null>,
- *             urls?: list<scalar|null>,
- *             scoped_clients?: list<scalar|null>,
- *             max_header_length?: int, // Max header length supported by the cache server. // Default: 7500
+ *             enabled?: bool|Param, // Default: false
+ *             varnish_urls?: list<scalar|null|Param>,
+ *             urls?: list<scalar|null|Param>,
+ *             scoped_clients?: list<scalar|null|Param>,
+ *             max_header_length?: int|Param, // Max header length supported by the cache server. // Default: 7500
  *             request_options?: mixed, // To pass options to the client charged with the request. // Default: []
- *             purger?: scalar|null, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
+ *             purger?: scalar|null|Param, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
  *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate paramters.
- *                 glue?: scalar|null, // xkey glue between keys // Default: " "
+ *                 glue?: scalar|null|Param, // xkey glue between keys // Default: " "
  *             },
  *         },
  *     },
  *     mercure?: bool|array{
- *         enabled?: bool, // Default: false
- *         hub_url?: scalar|null, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
- *         include_type?: bool, // Always include @type in updates (including delete ones). // Default: false
+ *         enabled?: bool|Param, // Default: false
+ *         hub_url?: scalar|null|Param, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
+ *         include_type?: bool|Param, // Always include @type in updates (including delete ones). // Default: false
  *     },
  *     messenger?: bool|array{
- *         enabled?: bool, // Default: false
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     elasticsearch?: bool|array{
- *         enabled?: bool, // Default: false
- *         hosts?: list<scalar|null>,
+ *         enabled?: bool|Param, // Default: false
+ *         hosts?: list<scalar|null|Param>,
  *     },
  *     openapi?: array{
  *         contact?: array{
- *             name?: scalar|null, // The identifying name of the contact person/organization. // Default: null
- *             url?: scalar|null, // The URL pointing to the contact information. MUST be in the format of a URL. // Default: null
- *             email?: scalar|null, // The email address of the contact person/organization. MUST be in the format of an email address. // Default: null
+ *             name?: scalar|null|Param, // The identifying name of the contact person/organization. // Default: null
+ *             url?: scalar|null|Param, // The URL pointing to the contact information. MUST be in the format of a URL. // Default: null
+ *             email?: scalar|null|Param, // The email address of the contact person/organization. MUST be in the format of an email address. // Default: null
  *         },
- *         termsOfService?: scalar|null, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
+ *         termsOfService?: scalar|null|Param, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
  *         tags?: list<array{ // Default: []
- *             name: scalar|null,
- *             description?: scalar|null, // Default: null
+ *             name: scalar|null|Param,
+ *             description?: scalar|null|Param, // Default: null
  *         }>,
  *         license?: array{
- *             name?: scalar|null, // The license name used for the API. // Default: null
- *             url?: scalar|null, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
- *             identifier?: scalar|null, // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field. // Default: null
+ *             name?: scalar|null|Param, // The license name used for the API. // Default: null
+ *             url?: scalar|null|Param, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
+ *             identifier?: scalar|null|Param, // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field. // Default: null
  *         },
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
- *         overrideResponses?: bool, // Whether API Platform adds automatic responses to the OpenAPI documentation. // Default: true
- *         error_resource_class?: scalar|null, // The class used to represent errors in the OpenAPI documentation. // Default: null
- *         validation_error_resource_class?: scalar|null, // The class used to represent validation errors in the OpenAPI documentation. // Default: null
+ *         overrideResponses?: bool|Param, // Whether API Platform adds automatic responses to the OpenAPI documentation. // Default: true
+ *         error_resource_class?: scalar|null|Param, // The class used to represent errors in the OpenAPI documentation. // Default: null
+ *         validation_error_resource_class?: scalar|null|Param, // The class used to represent validation errors in the OpenAPI documentation. // Default: null
  *     },
  *     maker?: bool|array{
- *         enabled?: bool, // Default: true
+ *         enabled?: bool|Param, // Default: true
  *     },
- *     exception_to_status?: array<string, int>,
+ *     exception_to_status?: array<string, int|Param>,
  *     formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]}}
- *         mime_types?: list<scalar|null>,
+ *         mime_types?: list<scalar|null|Param>,
  *     }>,
  *     patch_formats?: array<string, array{ // Default: {"json":{"mime_types":["application/merge-patch+json"]}}
- *         mime_types?: list<scalar|null>,
+ *         mime_types?: list<scalar|null|Param>,
  *     }>,
  *     docs_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonopenapi":{"mime_types":["application/vnd.openapi+json"]},"html":{"mime_types":["text/html"]},"yamlopenapi":{"mime_types":["application/vnd.openapi+yaml"]}}
- *         mime_types?: list<scalar|null>,
+ *         mime_types?: list<scalar|null|Param>,
  *     }>,
  *     error_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonproblem":{"mime_types":["application/problem+json"]},"json":{"mime_types":["application/problem+json","application/json"]}}
- *         mime_types?: list<scalar|null>,
+ *         mime_types?: list<scalar|null|Param>,
  *     }>,
- *     jsonschema_formats?: list<scalar|null>,
+ *     jsonschema_formats?: list<scalar|null|Param>,
  *     defaults?: array{
  *         uri_template?: mixed,
  *         short_name?: mixed,

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -29,6 +29,7 @@ use App\DataTables\Helpers\PartDataTableHelper;
 use App\Entity\Attachments\Attachment;
 use App\Entity\Parts\Part;
 use App\Entity\ProjectSystem\ProjectBOMEntry;
+use App\Services\ElementTypeNameGenerator;
 use App\Services\EntityURLGenerator;
 use App\Services\Formatters\AmountFormatter;
 use Doctrine\ORM\QueryBuilder;
@@ -41,7 +42,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProjectBomEntriesDataTable implements DataTableTypeInterface
 {
-    public function __construct(protected TranslatorInterface $translator, protected PartDataTableHelper $partDataTableHelper, protected EntityURLGenerator $entityURLGenerator, protected AmountFormatter $amountFormatter)
+    public function __construct(protected TranslatorInterface $translator, protected PartDataTableHelper $partDataTableHelper,
+        protected EntityURLGenerator $entityURLGenerator, protected AmountFormatter $amountFormatter, private readonly ElementTypeNameGenerator $elementTypeNameGenerator)
     {
     }
 
@@ -79,8 +81,8 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
                     return htmlspecialchars($this->amountFormatter->format($context->getQuantity(), $context->getPart()->getPartUnit()));
                 },
             ])
-			->add('part_id', TextColumn::class, [
-				'label' => 'part-id',
+			->add('partId', TextColumn::class, [
+				'label' => $this->translator->trans('project.bom.part_id'),
 				'visible' => true,
 				'orderField' => 'part.id',
 				'render' => function ($value, ProjectBOMEntry $context) {

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="messages.en">
     <unit id="x_wTSQS" name="attachment_type.caption">
@@ -221,7 +221,7 @@
       </notes>
       <segment state="final">
         <source>part.info.timetravel_hint</source>
-        <target>This is how the part appeared before %timestamp%. &lt;i&gt;Please note that this feature is experimental, so the info may not be correct.&lt;/i&gt;</target>
+        <target><![CDATA[This is how the part appeared before %timestamp%. <i>Please note that this feature is experimental, so the info may not be correct.</i>]]></target>
       </segment>
     </unit>
     <unit id="3exvSpl" name="standard.label">
@@ -649,10 +649,10 @@
       </notes>
       <segment state="translated">
         <source>user.edit.tfa.disable_tfa_message</source>
-        <target>This will disable &lt;b&gt;all active two-factor authentication methods of the user&lt;/b&gt; and delete the &lt;b&gt;backup codes&lt;/b&gt;!
-&lt;br&gt;
-The user will have to set up all two-factor authentication methods again and print new backup codes! &lt;br&gt;&lt;br&gt;
-&lt;b&gt;Only do this if you are absolutely sure about the identity of the user (seeking help), otherwise the account could be compromised by an attacker!&lt;/b&gt;</target>
+        <target><![CDATA[This will disable <b>all active two-factor authentication methods of the user</b> and delete the <b>backup codes</b>!
+<br>
+The user will have to set up all two-factor authentication methods again and print new backup codes! <br><br>
+<b>Only do this if you are absolutely sure about the identity of the user (seeking help), otherwise the account could be compromised by an attacker!</b>]]></target>
       </segment>
     </unit>
     <unit id="APsHYu0" name="user.edit.tfa.disable_tfa.btn">
@@ -803,9 +803,9 @@ The user will have to set up all two-factor authentication methods again and pri
       </notes>
       <segment state="translated">
         <source>entity.delete.message</source>
-        <target>This can not be undone!
-&lt;br&gt;
-Sub elements will be moved upwards.</target>
+        <target><![CDATA[This can not be undone!
+<br>
+Sub elements will be moved upwards.]]></target>
       </segment>
     </unit>
     <unit id="2tKAqHw" name="entity.delete">
@@ -1359,7 +1359,7 @@ Sub elements will be moved upwards.</target>
       </notes>
       <segment state="final">
         <source>homepage.github.text</source>
-        <target>Source, downloads, bug reports, to-do-list etc. can be found on &lt;a href="%href%" class="link-external" target="_blank"&gt;GitHub project page&lt;/a&gt;</target>
+        <target><![CDATA[Source, downloads, bug reports, to-do-list etc. can be found on <a href="%href%" class="link-external" target="_blank">GitHub project page</a>]]></target>
       </segment>
     </unit>
     <unit id="D5OKsgU" name="homepage.help.caption">
@@ -1381,7 +1381,7 @@ Sub elements will be moved upwards.</target>
       </notes>
       <segment state="translated">
         <source>homepage.help.text</source>
-        <target>Help and tips can be found in Wiki the &lt;a href="%href%" class="link-external" target="_blank"&gt;GitHub page&lt;/a&gt;</target>
+        <target><![CDATA[Help and tips can be found in Wiki the <a href="%href%" class="link-external" target="_blank">GitHub page</a>]]></target>
       </segment>
     </unit>
     <unit id="dnirx4v" name="homepage.forum.caption">
@@ -1623,7 +1623,7 @@ Sub elements will be moved upwards.</target>
       </notes>
       <segment state="translated">
         <source>email.pw_reset.fallback</source>
-        <target>If this does not work for you, go to &lt;a href="%url%"&gt;%url%&lt;/a&gt; and enter the following info</target>
+        <target><![CDATA[If this does not work for you, go to <a href="%url%">%url%</a> and enter the following info]]></target>
       </segment>
     </unit>
     <unit id="DduL9Hu" name="email.pw_reset.username">
@@ -1653,7 +1653,7 @@ Sub elements will be moved upwards.</target>
       </notes>
       <segment state="translated">
         <source>email.pw_reset.valid_unit %date%</source>
-        <target>The reset token will be valid until &lt;i&gt;%date%&lt;/i&gt;.</target>
+        <target><![CDATA[The reset token will be valid until <i>%date%</i>.]]></target>
       </segment>
     </unit>
     <unit id="8sBnjRy" name="orderdetail.delete">
@@ -3526,8 +3526,8 @@ Sub elements will be moved upwards.</target>
       </notes>
       <segment state="translated">
         <source>tfa_google.disable.confirm_message</source>
-        <target>If you disable the Authenticator App, all backup codes will be deleted, so you may need to reprint them.&lt;br&gt;
-Also note that without two-factor authentication, your account is no longer as well protected against attackers!</target>
+        <target><![CDATA[If you disable the Authenticator App, all backup codes will be deleted, so you may need to reprint them.<br>
+Also note that without two-factor authentication, your account is no longer as well protected against attackers!]]></target>
       </segment>
     </unit>
     <unit id="yu9MSt5" name="tfa_google.disabled_message">
@@ -3547,7 +3547,7 @@ Also note that without two-factor authentication, your account is no longer as w
       </notes>
       <segment state="translated">
         <source>tfa_google.step.download</source>
-        <target>Download an authenticator app (e.g. &lt;a class="link-external" target="_blank" href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2"&gt;Google Authenticator&lt;/a&gt; oder &lt;a class="link-external" target="_blank" href="https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp"&gt;FreeOTP Authenticator&lt;/a&gt;)</target>
+        <target><![CDATA[Download an authenticator app (e.g. <a class="link-external" target="_blank" href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2">Google Authenticator</a> oder <a class="link-external" target="_blank" href="https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp">FreeOTP Authenticator</a>)]]></target>
       </segment>
     </unit>
     <unit id="eriwJoR" name="tfa_google.step.scan">
@@ -3789,8 +3789,8 @@ Also note that without two-factor authentication, your account is no longer as w
       </notes>
       <segment state="translated">
         <source>tfa_trustedDevices.explanation</source>
-        <target>When checking the second factor, the current computer can be marked as trustworthy, so no more two-factor checks on this computer are needed.
-If you have done this incorrectly or if a computer is no longer trusted, you can reset the status of &lt;i&gt;all &lt;/i&gt;computers here.</target>
+        <target><![CDATA[When checking the second factor, the current computer can be marked as trustworthy, so no more two-factor checks on this computer are needed.
+If you have done this incorrectly or if a computer is no longer trusted, you can reset the status of <i>all </i>computers here.]]></target>
       </segment>
     </unit>
     <unit id="FZINq8z" name="tfa_trustedDevices.invalidate.confirm_title">
@@ -5236,7 +5236,7 @@ If you have done this incorrectly or if a computer is no longer trusted, you can
       </notes>
       <segment state="translated">
         <source>label_options.lines_mode.help</source>
-        <target>If you select Twig here, the content field is interpreted as Twig template. See &lt;a href="https://twig.symfony.com/doc/3.x/templates.html"&gt;Twig documentation&lt;/a&gt; and &lt;a href="https://docs.part-db.de/usage/labels.html#twig-mode"&gt;Wiki&lt;/a&gt; for more information.</target>
+        <target><![CDATA[If you select Twig here, the content field is interpreted as Twig template. See <a href="https://twig.symfony.com/doc/3.x/templates.html">Twig documentation</a> and <a href="https://docs.part-db.de/usage/labels.html#twig-mode">Wiki</a> for more information.]]></target>
       </segment>
     </unit>
     <unit id="isvxbiX" name="label_options.page_size.label">
@@ -7084,15 +7084,15 @@ Exampletown</target>
       </notes>
       <segment state="translated">
         <source>mass_creation.lines.placeholder</source>
-        <target>Element 1
+        <target><![CDATA[Element 1
    Element 1.1
       Element 1.1.1
    Element 1.2
 Element 2
 Element 3
 
-Element 1 -&gt; Element 1.1
-Element 1 -&gt; Element 1.2</target>
+Element 1 -> Element 1.1
+Element 1 -> Element 1.2]]></target>
       </segment>
     </unit>
     <unit id="TWSqPFi" name="entity.mass_creation.btn">
@@ -9152,25 +9152,25 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="r4vDLAt" name="filter.parameter_value_constraint.operator.&lt;">
       <segment state="translated">
         <source>filter.parameter_value_constraint.operator.&lt;</source>
-        <target>Typ. Value &lt;</target>
+        <target><![CDATA[Typ. Value <]]></target>
       </segment>
     </unit>
     <unit id="X9SA3UP" name="filter.parameter_value_constraint.operator.&gt;">
       <segment state="translated">
         <source>filter.parameter_value_constraint.operator.&gt;</source>
-        <target>Typ. Value &gt;</target>
+        <target><![CDATA[Typ. Value >]]></target>
       </segment>
     </unit>
     <unit id="BQGaoQS" name="filter.parameter_value_constraint.operator.&lt;=">
       <segment state="translated">
         <source>filter.parameter_value_constraint.operator.&lt;=</source>
-        <target>Typ. Value &lt;=</target>
+        <target><![CDATA[Typ. Value <=]]></target>
       </segment>
     </unit>
     <unit id="2ha3P6g" name="filter.parameter_value_constraint.operator.&gt;=">
       <segment state="translated">
         <source>filter.parameter_value_constraint.operator.&gt;=</source>
-        <target>Typ. Value &gt;=</target>
+        <target><![CDATA[Typ. Value >=]]></target>
       </segment>
     </unit>
     <unit id="4DaBace" name="filter.parameter_value_constraint.operator.BETWEEN">
@@ -9278,7 +9278,7 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="4tHhDtU" name="parts_list.search.searching_for">
       <segment state="translated">
         <source>parts_list.search.searching_for</source>
-        <target>Searching parts with keyword &lt;b&gt;%keyword%&lt;/b&gt;</target>
+        <target><![CDATA[Searching parts with keyword <b>%keyword%</b>]]></target>
       </segment>
     </unit>
     <unit id="4vomKLa" name="parts_list.search_options.caption">
@@ -10058,7 +10058,7 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="GzqIwHH" name="entity.select.add_hint">
       <segment state="translated">
         <source>entity.select.add_hint</source>
-        <target>Use -&gt; to create nested structures, e.g. "Node 1-&gt;Node 1.1"</target>
+        <target><![CDATA[Use -> to create nested structures, e.g. "Node 1->Node 1.1"]]></target>
       </segment>
     </unit>
     <unit id="S4CxO.T" name="entity.select.group.new_not_added_to_DB">
@@ -10082,13 +10082,13 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="XLnXtsR" name="homepage.first_steps.introduction">
       <segment state="translated">
         <source>homepage.first_steps.introduction</source>
-        <target>Your database is still empty. You might want to read the &lt;a href="%url%"&gt;documentation&lt;/a&gt; or start to creating the following data structures:</target>
+        <target><![CDATA[Your database is still empty. You might want to read the <a href="%url%">documentation</a> or start to creating the following data structures:]]></target>
       </segment>
     </unit>
     <unit id="Q79MOIk" name="homepage.first_steps.create_part">
       <segment state="translated">
         <source>homepage.first_steps.create_part</source>
-        <target>Or you can directly &lt;a href="%url%"&gt;create a new part&lt;/a&gt;.</target>
+        <target><![CDATA[Or you can directly <a href="%url%">create a new part</a>.]]></target>
       </segment>
     </unit>
     <unit id="vplYq4f" name="homepage.first_steps.hide_hint">
@@ -10100,7 +10100,7 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="MJoZl4f" name="homepage.forum.text">
       <segment state="translated">
         <source>homepage.forum.text</source>
-        <target>For questions about Part-DB use the &lt;a href="%href%" class="link-external" target="_blank"&gt;discussion forum&lt;/a&gt;</target>
+        <target><![CDATA[For questions about Part-DB use the <a href="%href%" class="link-external" target="_blank">discussion forum</a>]]></target>
       </segment>
     </unit>
     <unit id="YsukbnK" name="log.element_edited.changed_fields.category">
@@ -10766,7 +10766,7 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="p_IxB9K" name="parts.import.help_documentation">
       <segment state="translated">
         <source>parts.import.help_documentation</source>
-        <target>See the &lt;a href="%link%"&gt;documentation&lt;/a&gt; for more information on the file format.</target>
+        <target><![CDATA[See the <a href="%link%">documentation</a> for more information on the file format.]]></target>
       </segment>
     </unit>
     <unit id="awbvhVq" name="parts.import.help">
@@ -10958,7 +10958,7 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="o5u.Nnz" name="part.filter.lessThanDesired">
       <segment state="translated">
         <source>part.filter.lessThanDesired</source>
-        <target>In stock less than desired (total amount &lt; min. amount)</target>
+        <target><![CDATA[In stock less than desired (total amount < min. amount)]]></target>
       </segment>
     </unit>
     <unit id="YN9eLcZ" name="part.filter.lotOwner">
@@ -11764,13 +11764,13 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="i68lU5x" name="part.merge.confirm.title">
       <segment state="translated">
         <source>part.merge.confirm.title</source>
-        <target>Do you really want to merge &lt;b&gt;%other%&lt;/b&gt; into &lt;b&gt;%target%&lt;/b&gt;?</target>
+        <target><![CDATA[Do you really want to merge <b>%other%</b> into <b>%target%</b>?]]></target>
       </segment>
     </unit>
     <unit id="k0anzYV" name="part.merge.confirm.message">
       <segment state="translated">
         <source>part.merge.confirm.message</source>
-        <target>&lt;b&gt;%other%&lt;/b&gt; will be deleted, and the part will be saved with the shown information.</target>
+        <target><![CDATA[<b>%other%</b> will be deleted, and the part will be saved with the shown information.]]></target>
       </segment>
     </unit>
     <unit id="mmW5Yl1" name="part.info.merge_modal.title">
@@ -12124,7 +12124,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="p7LGAIX" name="settings.ips.element14.apiKey.help">
       <segment state="translated">
         <source>settings.ips.element14.apiKey.help</source>
-        <target>You can register for an API key on &lt;a href="https://partner.element14.com/"&gt;https://partner.element14.com/&lt;/a&gt;.</target>
+        <target><![CDATA[You can register for an API key on <a href="https://partner.element14.com/">https://partner.element14.com/</a>.]]></target>
       </segment>
     </unit>
     <unit id="ZdUHpZc" name="settings.ips.element14.storeId">
@@ -12136,7 +12136,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="XXGUxF6" name="settings.ips.element14.storeId.help">
       <segment state="translated">
         <source>settings.ips.element14.storeId.help</source>
-        <target>The store domain to retrieve the data from. This decides the language and currency of results. See &lt;a href="https://partner.element14.com/docs/Product_Search_API_REST__Description"&gt;here&lt;/a&gt; for a list of valid domains.</target>
+        <target><![CDATA[The store domain to retrieve the data from. This decides the language and currency of results. See <a href="https://partner.element14.com/docs/Product_Search_API_REST__Description">here</a> for a list of valid domains.]]></target>
       </segment>
     </unit>
     <unit id="WKWZIm2" name="settings.ips.tme">
@@ -12154,7 +12154,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="_pYLrPT" name="settings.ips.tme.token.help">
       <segment state="translated">
         <source>settings.ips.tme.token.help</source>
-        <target>You can get an API token and secret on &lt;a href="https://developers.tme.eu/en/"&gt;https://developers.tme.eu/en/&lt;/a&gt;.</target>
+        <target><![CDATA[You can get an API token and secret on <a href="https://developers.tme.eu/en/">https://developers.tme.eu/en/</a>.]]></target>
       </segment>
     </unit>
     <unit id="yswx4bq" name="settings.ips.tme.secret">
@@ -12202,7 +12202,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="gu.JlpT" name="settings.ips.mouser.apiKey.help">
       <segment state="translated">
         <source>settings.ips.mouser.apiKey.help</source>
-        <target>You can register for an API key on &lt;a href="https://eu.mouser.com/api-hub/"&gt;https://eu.mouser.com/api-hub/&lt;/a&gt;.</target>
+        <target><![CDATA[You can register for an API key on <a href="https://eu.mouser.com/api-hub/">https://eu.mouser.com/api-hub/</a>.]]></target>
       </segment>
     </unit>
     <unit id="Q66CNjw" name="settings.ips.mouser.searchLimit">
@@ -12280,7 +12280,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="kKv0J3." name="settings.system.attachments">
       <segment state="translated">
         <source>settings.system.attachments</source>
-        <target>Attachments &amp; Files</target>
+        <target><![CDATA[Attachments & Files]]></target>
       </segment>
     </unit>
     <unit id="dsRff8T" name="settings.system.attachments.maxFileSize">
@@ -12304,7 +12304,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="T.PBu5P" name="settings.system.attachments.allowDownloads.help">
       <segment state="translated">
         <source>settings.system.attachments.allowDownloads.help</source>
-        <target>With this option users can download external files into Part-DB by providing an URL. &lt;b&gt;Attention: This can be a security issue, as it might allow users to access intranet ressources via Part-DB!&lt;/b&gt;</target>
+        <target><![CDATA[With this option users can download external files into Part-DB by providing an URL. <b>Attention: This can be a security issue, as it might allow users to access intranet ressources via Part-DB!</b>]]></target>
       </segment>
     </unit>
     <unit id=".OyihML" name="settings.system.attachments.downloadByDefault">
@@ -12478,8 +12478,8 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="0GRlEe5" name="settings.system.localization.base_currency_description">
       <segment state="translated">
         <source>settings.system.localization.base_currency_description</source>
-        <target>The currency that is used to store price information and exchange rates in. This currency is assumed, when no currency is set for a price information.
-&lt;b&gt;Please note that the currencies are not converted, when changing this value. So changing the default currency after you already added price information, will result in wrong prices!&lt;/b&gt;</target>
+        <target><![CDATA[The currency that is used to store price information and exchange rates in. This currency is assumed, when no currency is set for a price information.
+<b>Please note that the currencies are not converted, when changing this value. So changing the default currency after you already added price information, will result in wrong prices!</b>]]></target>
       </segment>
     </unit>
     <unit id="cvpTUeY" name="settings.system.privacy">
@@ -12509,7 +12509,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="w07P3Dt" name="settings.misc.kicad_eda.category_depth.help">
       <segment state="translated">
         <source>settings.misc.kicad_eda.category_depth.help</source>
-        <target>This value determines the depth of the category tree, that is visible inside KiCad. 0 means that only the top level categories are visible. Set to a value &gt; 0 to show more levels. Set to -1, to show all parts of Part-DB inside a sigle cnategory in KiCad.</target>
+        <target><![CDATA[This value determines the depth of the category tree, that is visible inside KiCad. 0 means that only the top level categories are visible. Set to a value > 0 to show more levels. Set to -1, to show all parts of Part-DB inside a sigle cnategory in KiCad.]]></target>
       </segment>
     </unit>
     <unit id="VwvmcWE" name="settings.behavior.sidebar">
@@ -12527,7 +12527,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="jc0JTvL" name="settings.behavior.sidebar.items.help">
       <segment state="translated">
         <source>settings.behavior.sidebar.items.help</source>
-        <target>The menus which appear at the sidebar by default. Order of items can be changed via drag &amp; drop.</target>
+        <target><![CDATA[The menus which appear at the sidebar by default. Order of items can be changed via drag & drop.]]></target>
       </segment>
     </unit>
     <unit id="gVSWDkE" name="settings.behavior.sidebar.rootNodeEnabled">
@@ -12575,7 +12575,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="SUD8H3b" name="settings.behavior.table.parts_default_columns.help">
       <segment state="translated">
         <source>settings.behavior.table.parts_default_columns.help</source>
-        <target>The columns to show by default in part tables. Order of items can be changed via drag &amp; drop.</target>
+        <target><![CDATA[The columns to show by default in part tables. Order of items can be changed via drag & drop.]]></target>
       </segment>
     </unit>
     <unit id="hazr_g5" name="settings.ips.oemsecrets">
@@ -12629,7 +12629,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="KLJYfJ0" name="settings.ips.oemsecrets.sortMode.M">
       <segment state="translated">
         <source>settings.ips.oemsecrets.sortMode.M</source>
-        <target>Completeness &amp; Manufacturer name</target>
+        <target><![CDATA[Completeness & Manufacturer name]]></target>
       </segment>
     </unit>
     <unit id="8C9ijHM" name="entity.export.flash.error.no_entities">
@@ -13289,7 +13289,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="FsrRdkp" name="settings.behavior.homepage.items.help">
       <segment state="translated">
         <source>settings.behavior.homepage.items.help</source>
-        <target>The items to show at the homepage. Order can be changed via drag &amp; drop.</target>
+        <target><![CDATA[The items to show at the homepage. Order can be changed via drag & drop.]]></target>
       </segment>
     </unit>
     <unit id="CYw3_pS" name="settings.system.customization.showVersionOnHomepage">
@@ -14003,7 +14003,7 @@ Please note, that you can not impersonate a disabled user. If you try you will g
     <unit id="Ej2znKK" name="settings.system.localization.language_menu_entries.description">
       <segment state="translated">
         <source>settings.system.localization.language_menu_entries.description</source>
-        <target>The languages to show in the language drop-down menu. Order can be changed via drag &amp; drop. Leave empty to show all available languages.</target>
+        <target><![CDATA[The languages to show in the language drop-down menu. Order can be changed via drag & drop. Leave empty to show all available languages.]]></target>
       </segment>
     </unit>
     <unit id="xIZ_mEX" name="project.builds.no_bom_entries">
@@ -14279,13 +14279,19 @@ Please note that this system is currently experimental, and the synonyms defined
       </segment>
     </unit>
     <unit id="MxKRRx_" name="datatable.datatable.lengthMenu">
-        <notes>
-            <note priority="1">Do not remove! Used for datatables rendering.</note>
-        </notes>
-        <segment state="translated">
-            <source>datatable.datatable.lengthMenu</source>
-            <target>_MENU_</target>
-          </segment>
+      <notes>
+        <note priority="1">Do not remove! Used for datatables rendering.</note>
+      </notes>
+      <segment state="translated">
+        <source>datatable.datatable.lengthMenu</source>
+        <target>_MENU_</target>
+      </segment>
+    </unit>
+    <unit id="8BkjGyq" name="project.bom.part_id">
+      <segment>
+        <source>project.bom.part_id</source>
+        <target>[Part] ID</target>
+      </segment>
     </unit>
   </file>
 </xliff>


### PR DESCRIPTION
Adds a new visible column part-id to the Project BOM overview

- The column displays the real Part database ID (Part::getId()), not the Project BOM entry ID
- Column is sortable via part.id

For BOM entries without a linked Part, the column remains empty
Trying to add https://github.com/Part-DB/Part-DB-server/issues/1161
