### PR TITLE
Fix #1165: Label generator PDF viewer could be a few px longer

### DIFF
--- a/templates/label_system/dialog.html.twig
+++ b/templates/label_system/dialog.html.twig
@@ -135,8 +135,8 @@
 
 {% block additional_content %}
     {% if pdf_data %}
-        <div class="card mt-2 p-1 border-secondary" style="resize: vertical; overflow: scroll; height: 250px">
-            <object id="pdf_preview"  data="{{ pdf_data | data_uri(mime='application/pdf') }}"style="height: inherit">
+        <div class="card mt-2 p-1 border-secondary" style="resize: vertical; overflow: scroll; height: 280px">
+            <object id="pdf_preview"  data="{{ pdf_data | data_uri(mime='application/pdf') }}" style="height: inherit">
             </object>
         </div>
     {% endif %}


### PR DESCRIPTION
Increase default height of the PDF preview container from 250px to 280px and so Chromium-based browsers display the PDF toolbar by default. Fixes #1165.