### PR TITLE
Added Exact ID Search Option (Disabled by Default)

### DIFF
--- a/src/Controller/PartListsController.php
+++ b/src/Controller/PartListsController.php
@@ -319,6 +319,7 @@ class PartListsController extends AbstractController
 
         //As an unchecked checkbox is not set in the query, the default value for all bools have to be false (which is the default argument value)!
         $filter->setName($request->query->getBoolean('name'));
+        $filter->setDbId($request->query->getBoolean('dbid'));
         $filter->setCategory($request->query->getBoolean('category'));
         $filter->setDescription($request->query->getBoolean('description'));
         $filter->setMpn($request->query->getBoolean('mpn'));

--- a/templates/components/search.macro.html.twig
+++ b/templates/components/search.macro.html.twig
@@ -12,6 +12,10 @@
                     <label for="search_name" class="form-check-label justify-content-start">{% trans %}name.label{% endtrans %}</label>
                 </div>
                 <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="search_dbid" name="dbid" value="1" checked {{ stimulus_controller('elements/localStorage_checkbox') }}>
+                    <label for="search_dbid" class="form-check-label justify-content-start">{% trans %}id.label{% endtrans %}</label>
+                </div>
+                <div class="form-check">
                     <input type="checkbox" class="form-check-input" id="search_category" name="category" value="1" checked {{ stimulus_controller('elements/localStorage_checkbox') }}>
                     <label for="search_category" class="form-check-label justify-content-start">{% trans %}category.label{% endtrans %}</label>
                 </div>


### PR DESCRIPTION
I reworked my latest pull request. Now it introduced an ID search option that is disabled by default. ID search now uses exact match (=) instead of LIKE.

The filter applies only when:
- The ID search option is enabled and
- the keyword is numeric.

 Updated apply() in PartSearchFilter.php to implement this logic while preserving previous functionality for other fields.