### PR TITLE
Change barcode scan form to use requestSubmit() to fix CSRF token error

### DIFF
--- a/assets/controllers/pages/barcode_scan_controller.js
+++ b/assets/controllers/pages/barcode_scan_controller.js
@@ -70,6 +70,6 @@ export default class extends Controller {
         //Put our decoded Text into the input box
         document.getElementById('scan_dialog_input').value = decodedText;
         //Submit form
-        document.getElementById('scan_dialog_form').submit();
+        document.getElementById('scan_dialog_form').requestSubmit();
     }
 }


### PR DESCRIPTION
On the Label Scanner page I have developed scanning of LCSC barcodes.  During testing the redirect to the Part page was not working and I was getting CSRF token errors and the request failing with a HTTP 422 error.

I noticed that the CSRF Token value being sent on the form submission had the placeholder text  `scan_dialog[_token]
csrf-token `, so the token itself was not being generated and submitted.

In the assets/controllers/csrf_protection_controller.js  file it specifically states;
```
// Generate and double-submit a CSRF token in a form field and a cookie, as defined by Symfony's SameOriginCsrfTokenManager
// Use `form.requestSubmit()` to ensure that the submit event is triggered. Using `form.submit()` will not trigger the event
// and thus this event-listener will not be executed.
```

Sure enough the Label Scanner form submission was using `form.submit()` and not the required `form.requestSubmit()`.    This PR patches that bug so CSRF token is now correctly generated on form submission.

I further note that this bug maybe present else where in the code as a grep shows;
```
$ rg -n "\.submit\(\)|requestSubmit\(" -S assets/controllers

assets/controllers/csrf_protection_controller.js
5:// Use `form.requestSubmit()` to ensure that the submit event is triggered. Using `form.submit()` will not trigger the event

assets/controllers/pages/barcode_scan_controller.js
73:        document.getElementById('scan_dialog_form').submit();

assets/controllers/helpers/form_cleanup_controller.js
65:        form.submit();

assets/controllers/elements/part_search_controller.js
122:                input.form.requestSubmit();

assets/controllers/elements/datatables/parts_controller.js
143:        //We need to do this that way, as we need the submitter info, just calling form.submit() would not work
```
The other possible bug is in the `assets/controllers/helpers/form_cleanup_controller.js` file, but as I am not sure which part of the code this effects, I have not proposed a change here.  However that could be the failure for other CSRF issues in #911 and #1095