### PR TITLE
fix(KiCad API): :bug: new categories excluded from simulation

### DIFF
--- a/src/Entity/EDA/EDACategoryInfo.php
+++ b/src/Entity/EDA/EDACategoryInfo.php
@@ -58,7 +58,7 @@ class EDACategoryInfo
     /** @var bool|null If this is set to true, then this part will be excluded in the simulation */
     #[Column(type: Types::BOOLEAN, nullable: true)]
     #[Groups(['full', 'category:read', 'category:write', 'import'])]
-    private ?bool $exclude_from_sim = true;
+    private ?bool $exclude_from_sim = null;
 
     /** @var string|null The KiCAD schematic symbol, which should be used (the path to the library) */
     #[Column(type: Types::STRING, nullable: true)]

--- a/src/Services/EDA/KiCadHelper.php
+++ b/src/Services/EDA/KiCadHelper.php
@@ -189,7 +189,7 @@ class KiCadHelper
             "symbolIdStr" => $part->getEdaInfo()->getKicadSymbol() ?? $part->getCategory()?->getEdaInfo()->getKicadSymbol() ?? "",
             "exclude_from_bom" => $this->boolToKicadBool($part->getEdaInfo()->getExcludeFromBom() ?? $part->getCategory()?->getEdaInfo()->getExcludeFromBom() ?? false),
             "exclude_from_board" => $this->boolToKicadBool($part->getEdaInfo()->getExcludeFromBoard() ?? $part->getCategory()?->getEdaInfo()->getExcludeFromBoard() ?? false),
-            "exclude_from_sim" => $this->boolToKicadBool($part->getEdaInfo()->getExcludeFromSim() ?? $part->getCategory()?->getEdaInfo()->getExcludeFromSim() ?? true),
+            "exclude_from_sim" => $this->boolToKicadBool($part->getEdaInfo()->getExcludeFromSim() ?? $part->getCategory()?->getEdaInfo()->getExcludeFromSim() ?? false),
             "fields" => []
         ];
 


### PR DESCRIPTION
Hi @jbtronics,

first of all - thank you for developing and maintaining this incredible piece of software. 🙏

When initially adding all my parts to `Part-DB` with the defaults provided, I just discovered that categories get created with `excluded_from_sim` set to `true`. When also creating all parts with the default of `null` (which means `inherit` from category) then all parts are per default excluded from simulation when adding them to KiCad via the API endpoint. This means that in older versions of KiCad (pre v9) newly placed parts are initially shown crossed out

<img width="147" height="139" alt="Bildschirmfoto 2026-01-15 um 19 27 48" src="https://github.com/user-attachments/assets/f684eac1-ed38-44a8-b9a2-d0ed310961a9" />

and in newer versions (v9 and newer) they get outlined and shown with an additional tag on the bottom right side

<img width="218" height="232" alt="Bildschirmfoto 2026-01-15 um 19 29 26" src="https://github.com/user-attachments/assets/3b5a83a4-9cf5-48ef-9135-95adaec17fa1" />

indicating that they are excluded from simulation.

This is rather annoying as changing this now requires manual adjustment of that setting for every single category in existence. This could only be made easier for existing users by providing some kind of batch editing feature which as far as I know is not a thing.

To at least mitigate this inconvenience for new users and new categories that existing users create, this PR proposes to set `excluded_from_sim` to `null` for new categories and default to `false` in the helper function if the property is not set.

Best regards,
@lukas-runge

