### PR TITLE
/api/part_lots: add user_barcode filter

### DIFF
--- a/src/Entity/Parts/PartLot.php
+++ b/src/Entity/Parts/PartLot.php
@@ -27,7 +27,6 @@ use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
 use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
-use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
@@ -82,11 +81,10 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     denormalizationContext: ['groups' => ['part_lot:write', 'api:basic:write'], 'openapi_definition_name' => 'Write'],
 )]
 #[ApiFilter(PropertyFilter::class)]
-#[ApiFilter(LikeFilter::class, properties: ["description", "comment"])]
+#[ApiFilter(LikeFilter::class, properties: ["description", "comment", "user_barcode"])]
 #[ApiFilter(DateFilter::class, strategy: DateFilterInterface::EXCLUDE_NULL)]
 #[ApiFilter(BooleanFilter::class, properties: ['instock_unknown', 'needs_refill'])]
 #[ApiFilter(RangeFilter::class, properties: ['amount'])]
-#[ApiFilter(SearchFilter::class, properties: ['user_barcode' => 'exact'])]
 #[ApiFilter(OrderFilter::class, properties: ['description', 'comment', 'addedDate', 'lastModified'])]
 class PartLot extends AbstractDBElement implements TimeStampableInterface, NamedElementInterface
 {

--- a/tests/API/Endpoints/PartLotsEndpointTest.php
+++ b/tests/API/Endpoints/PartLotsEndpointTest.php
@@ -60,6 +60,19 @@ final class PartLotsEndpointTest extends CrudEndpointTestCase
         self::assertSame('/api/part_lots/2', $json['hydra:member'][0]['@id']);
     }
 
+    public function testFilterByUserBarcodeUsingWildcard(): void
+    {
+        $response = self::createAuthenticatedClient()->request('GET', '/api/part_lots?user_barcode=lot2_%');
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'hydra:totalItems' => 1,
+        ]);
+
+        $json = $response->toArray();
+        self::assertSame('/api/part_lots/2', $json['hydra:member'][0]['@id']);
+    }
+
     public function testCreateItem(): void
     {
         $this->_testPostItem([


### PR DESCRIPTION
This pull request adds support for filtering `PartLot` entities by the `user_barcode` field via the API.
This is helpful, when interacting with the API using custom tooling.
