### PR TITLE
fix(scanner): use ZXing WASM detector for harder DigiKey Data Matrix labels

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -48,6 +48,7 @@ global.$ = global.jQuery = require("jquery");
 
 //Use the local WASM file for the ZXing library
 import {
+    BarcodeDetector as ZXingBarcodeDetector,
     setZXingModuleOverrides,
 } from "barcode-detector/ponyfill";
 import  wasmFile from "../../node_modules/zxing-wasm/dist/reader/zxing_reader.wasm";
@@ -59,3 +60,7 @@ setZXingModuleOverrides({
         return prefix + path;
     },
 });
+
+// Prefer the ZXing WASM detector over inconsistent native BarcodeDetector implementations.
+// This improves Data Matrix decoding reliability for difficult DigiKey labels (see #1281).
+globalThis.BarcodeDetector = ZXingBarcodeDetector;


### PR DESCRIPTION
## Summary
- force Part-DB's scanner path to use the ZXing WASM BarcodeDetector ponyfill instead of the browser-native detector
- keep the existing local WASM override wiring, but make the detector choice deterministic for scanning
- this targets issue reports where native detector paths fail on bolder/low-contrast DigiKey Data Matrix prints

## Testing
- not runnable in this checkout: frontend install fails because required Symfony UX asset paths under vendor/ are absent (vendor/symfony/ux-translator/assets), so yarn install --frozen-lockfile cannot complete
- manual verification plan documented in PR: confirm previously failing DigiKey white-bag labels decode on Chrome/Android + iOS after rebuilding assets

## Related
Fixes #1281