### PR TITLE
Fix #1305: Enable BOM sorting on part fields (Storage location, Manufacturing status) and fix BOM table query/pagination issues

### DIFF
--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -152,7 +152,6 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
             ->add('manufacturing_status', EnumColumn::class, [
                 'label' => $this->translator->trans('part.table.manufacturingStatus'),
-		        'data' => static fn(ProjectBOMEntry $context): ?ManufacturingStatus => $context->getPart()?->getManufacturingStatus(),
                	'class' => ManufacturingStatus::class,
                 'render' => function (?ManufacturingStatus $status, ProjectBOMEntry $context): string {
                     if ($status === null) {

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -185,6 +185,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ])
             ->add('storageLocations', TextColumn::class, [
                 'label' => 'part.table.storeLocations',
+                'orderField' => 'NATSORT(MIN(storageLocations.name))',
                 'visible' => false,
                 'render' => function ($value, ProjectBOMEntry $context) {
                     if ($context->getPart() !== null) {

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -195,7 +195,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
                     return '';
                 }
-            ], alias: 'storage_location')
+            ])
 
             ->add('addedDate', LocaleDateTimeColumn::class, [
                 'label' => $this->translator->trans('part.table.addedDate'),

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -185,7 +185,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ])
             ->add('storageLocations', TextColumn::class, [
                 'label' => 'part.table.storeLocations',
-                'orderField' => 'NATSORT(MIN(storageLocations.name))',
+                'orderField' => 'NATSORT(storageLocationOrder)',
                 'visible' => false,
                 'render' => function ($value, ProjectBOMEntry $context) {
                     if ($context->getPart() !== null) {
@@ -226,6 +226,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
     {
         $builder->select('bom_entry')
             ->addSelect('part')
+            ->addSelect('(SELECT MIN(storageLocationSort.name) FROM ' . \App\Entity\Parts\PartLot::class . ' partLotSort LEFT JOIN partLotSort.storage_location storageLocationSort WHERE partLotSort.part = part) AS HIDDEN storageLocationOrder')
             ->from(ProjectBOMEntry::class, 'bom_entry')
             ->leftJoin('bom_entry.part', 'part')
             ->leftJoin('part.category', 'category')

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -183,9 +183,10 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
                     return '';
                 }
             ])
-            ->add('storageLocations', TextColumn::class, [
-                'label' => 'part.table.storeLocations',
-                'orderField' => 'NATSORT(MIN(storageLocations.name))',
+            ->add('storelocation', TextColumn::class, [
+                'label' => $this->translator->trans('part.table.storeLocations'),
+                //We need to use a aggregate function to get the first store location, as we have a one-to-many relation
+                'orderField' => 'NATSORT(MIN(_storelocations.name))',
                 'visible' => false,
                 'render' => function ($value, ProjectBOMEntry $context) {
                     if ($context->getPart() !== null) {
@@ -194,7 +195,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
                     return '';
                 }
-            ])
+            ], alias: 'storage_location')
 
             ->add('addedDate', LocaleDateTimeColumn::class, [
                 'label' => $this->translator->trans('part.table.addedDate'),
@@ -229,12 +230,22 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->from(ProjectBOMEntry::class, 'bom_entry')
             ->leftJoin('bom_entry.part', 'part')
             ->leftJoin('part.category', 'category')
+            ->leftJoin('part.partLots', 'partLots')
+            ->leftJoin('partLots.storage_location', 'storelocations')
             ->leftJoin('part.footprint', 'footprint')
             ->leftJoin('part.manufacturer', 'manufacturer')
-            ->leftJoin('part.partLots', 'partLots')
-            ->leftJoin('partLots.storage_location', 'storageLocations')
+            ->leftJoin('part.partCustomState', 'partCustomState')
             ->where('bom_entry.project = :project')
             ->setParameter('project', $options['project'])
+
+            //We have to group by all elements, or only the first sub elements of an association is fetched! (see issue #190)
+            ->addGroupBy('part')
+            ->addGroupBy('partLots')
+            ->addGroupBy('category')
+            ->addGroupBy('storelocations')
+            ->addGroupBy('footprint')
+            ->addGroupBy('manufacturer')
+            ->addGroupBy('partCustomState')
         ;
     }
 

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -36,6 +36,7 @@ use App\Services\ElementTypeNameGenerator;
 use App\Services\EntityURLGenerator;
 use App\Services\Formatters\AmountFormatter;
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORM\SearchCriteriaProvider;
 use Omines\DataTablesBundle\Column\TextColumn;
@@ -287,6 +288,9 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->addGroupBy('footprint')
             ->addGroupBy('manufacturer')
             ->addGroupBy('partCustomState')
+
+            ->setHint(Query::HINT_READ_ONLY, true)
+            ->setHint(Query::HINT_FORCE_PARTIAL_LOAD, false)
         ;
 
         FieldHelper::addOrderByFieldParam($builder, 'bom_entry.id', 'ids');

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -231,6 +231,8 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->leftJoin('part.category', 'category')
             ->leftJoin('part.footprint', 'footprint')
             ->leftJoin('part.manufacturer', 'manufacturer')
+            ->leftJoin('part.partLots', 'partLots')
+            ->leftJoin('partLots.storage_location', 'storageLocations')
             ->where('bom_entry.project = :project')
             ->setParameter('project', $options['project'])
         ;

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -22,21 +22,22 @@ declare(strict_types=1);
 
 namespace App\DataTables;
 
+use App\DataTables\Adapters\TwoStepORMAdapter;
 use App\DataTables\Column\EntityColumn;
 use App\DataTables\Column\EnumColumn;
 use App\DataTables\Column\LocaleDateTimeColumn;
 use App\DataTables\Column\MarkdownColumn;
 use App\DataTables\Helpers\PartDataTableHelper;
-use App\Entity\Attachments\Attachment;
+use App\Doctrine\Helpers\FieldHelper;
 use App\Entity\Parts\Part;
 use App\Entity\Parts\ManufacturingStatus;
 use App\Entity\ProjectSystem\ProjectBOMEntry;
 use App\Services\ElementTypeNameGenerator;
 use App\Services\EntityURLGenerator;
 use App\Services\Formatters\AmountFormatter;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\QueryBuilder;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORM\SearchCriteriaProvider;
-use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\DataTableTypeInterface;
@@ -152,6 +153,8 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
             ->add('manufacturing_status', EnumColumn::class, [
                 'label' => $this->translator->trans('part.table.manufacturingStatus'),
+                'data' => static fn(ProjectBOMEntry $context): ?ManufacturingStatus => $context->getPart()?->getManufacturingStatus(),
+                'orderField' => 'part.manufacturing_status',
                	'class' => ManufacturingStatus::class,
                 'render' => function (?ManufacturingStatus $status, ProjectBOMEntry $context): string {
                     if ($status === null) {
@@ -211,11 +214,13 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
         $dataTable->addOrderBy('name', DataTable::SORT_ASCENDING);
 
-        $dataTable->createAdapter(ORMAdapter::class, [
-            'entity' => Attachment::class,
-            'query' => function (QueryBuilder $builder) use ($options): void {
-                $this->getQuery($builder, $options);
+        $dataTable->createAdapter(TwoStepORMAdapter::class, [
+            'entity' => ProjectBOMEntry::class,
+            'hydrate' => AbstractQuery::HYDRATE_OBJECT,
+            'filter_query' => function (QueryBuilder $builder) use ($options): void {
+                $this->getFilterQuery($builder, $options);
             },
+            'detail_query' => $this->getDetailQuery(...),
             'criteria' => [
                 function (QueryBuilder $builder) use ($options): void {
                     $this->buildCriteria($builder, $options);
@@ -225,11 +230,45 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
         ]);
     }
 
-    private function getQuery(QueryBuilder $builder, array $options): void
+    private function getFilterQuery(QueryBuilder $builder, array $options): void
     {
         $builder
-        	->select('bom_entry')
+            ->select('bom_entry.id')
+            ->from(ProjectBOMEntry::class, 'bom_entry')
+            ->leftJoin('bom_entry.part', 'part')
+            ->leftJoin('part.category', 'category')
+            ->leftJoin('part.partLots', '_partLots')
+            ->leftJoin('_partLots.storage_location', '_storelocations')
+            ->leftJoin('part.footprint', 'footprint')
+            ->leftJoin('part.manufacturer', 'manufacturer')
+            ->leftJoin('part.partCustomState', 'partCustomState')
+            ->where('bom_entry.project = :project')
+            ->setParameter('project', $options['project'])
+            ->addGroupBy('bom_entry')
+            ->addGroupBy('part')
+            ->addGroupBy('category')
+            ->addGroupBy('footprint')
+            ->addGroupBy('manufacturer')
+            ->addGroupBy('partCustomState')
+        ;
+    }
+
+    private function getDetailQuery(QueryBuilder $builder, array $filter_results): void
+    {
+        $ids = array_map(static fn (array $row) => $row['id'], $filter_results);
+        if ($ids === []) {
+            $ids = [-1];
+        }
+
+        $builder
+            ->select('bom_entry')
             ->addSelect('part')
+            ->addSelect('category')
+            ->addSelect('partLots')
+            ->addSelect('storelocations')
+            ->addSelect('footprint')
+            ->addSelect('manufacturer')
+            ->addSelect('partCustomState')
             ->from(ProjectBOMEntry::class, 'bom_entry')
             ->leftJoin('bom_entry.part', 'part')
             ->leftJoin('part.category', 'category')
@@ -238,9 +277,9 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->leftJoin('part.footprint', 'footprint')
             ->leftJoin('part.manufacturer', 'manufacturer')
             ->leftJoin('part.partCustomState', 'partCustomState')
-            ->where('bom_entry.project = :project')
-            ->setParameter('project', $options['project'])
-
+            ->where('bom_entry.id IN (:ids)')
+            ->setParameter('ids', $ids)
+            ->addGroupBy('bom_entry')
             ->addGroupBy('part')
             ->addGroupBy('partLots')
             ->addGroupBy('category')
@@ -249,6 +288,8 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->addGroupBy('manufacturer')
             ->addGroupBy('partCustomState')
         ;
+
+        FieldHelper::addOrderByFieldParam($builder, 'bom_entry.id', 'ids');
     }
 
     private function buildCriteria(QueryBuilder $builder, array $options): void

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -149,7 +149,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
             ->add('manufacturing_status', EnumColumn::class, [
                 'label' => $this->translator->trans('part.table.manufacturingStatus'),
-		'data' => static fn(ProjectBOMEntry $context): ?ManufacturingStatus => $context->getPart()?->getManufacturingStatus(),
+		        'data' => static fn(ProjectBOMEntry $context): ?ManufacturingStatus => $context->getPart()?->getManufacturingStatus(),
                	'class' => ManufacturingStatus::class,
                 'render' => function (?ManufacturingStatus $status, ProjectBOMEntry $context): string {
                     if ($status === null) {

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -1,8 +1,5 @@
 <?php
-
-declare(strict_types=1);
-
-/*
+/**
  * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
  *
  *  Copyright (C) 2019 - 2022 Jan Böhmer (https://github.com/jbtronics)
@@ -20,6 +17,9 @@ declare(strict_types=1);
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+declare(strict_types=1);
+
 namespace App\DataTables;
 
 use App\DataTables\Column\EntityColumn;
@@ -44,9 +44,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProjectBomEntriesDataTable implements DataTableTypeInterface
 {
-    public function __construct(protected TranslatorInterface $translator, protected PartDataTableHelper $partDataTableHelper,
-        protected EntityURLGenerator $entityURLGenerator, protected AmountFormatter $amountFormatter)
-    {
+    public function __construct(
+        protected EntityURLGenerator $entityURLGenerator,
+        protected TranslatorInterface $translator,
+        protected AmountFormatter $amountFormatter,
+        protected PartDataTableHelper $partDataTableHelper
+    ) {
     }
 
 
@@ -62,7 +65,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
                         return '';
                     }
                     return $this->partDataTableHelper->renderPicture($context->getPart());
-                },
+                }
             ])
 
             ->add('id', TextColumn::class, [
@@ -133,18 +136,18 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->add('category', EntityColumn::class, [
                 'label' => $this->translator->trans('part.table.category'),
                 'property' => 'part.category',
-                'orderField' => 'NATSORT(category.name)',
+                'orderField' => 'NATSORT(category.name)'
             ])
             ->add('footprint', EntityColumn::class, [
                 'property' => 'part.footprint',
                 'label' => $this->translator->trans('part.table.footprint'),
-                'orderField' => 'NATSORT(footprint.name)',
+                'orderField' => 'NATSORT(footprint.name)'
             ])
 
             ->add('manufacturer', EntityColumn::class, [
                 'property' => 'part.manufacturer',
                 'label' => $this->translator->trans('part.table.manufacturer'),
-                'orderField' => 'NATSORT(manufacturer.name)',
+                'orderField' => 'NATSORT(manufacturer.name)'
             ])
 
             ->add('manufacturing_status', EnumColumn::class, [
@@ -225,7 +228,8 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
 
     private function getQuery(QueryBuilder $builder, array $options): void
     {
-        $builder->select('bom_entry')
+        $builder
+        	->select('bom_entry')
             ->addSelect('part')
             ->from(ProjectBOMEntry::class, 'bom_entry')
             ->leftJoin('bom_entry.part', 'part')
@@ -238,7 +242,6 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ->where('bom_entry.project = :project')
             ->setParameter('project', $options['project'])
 
-            //We have to group by all elements, or only the first sub elements of an association is fetched! (see issue #190)
             ->addGroupBy('part')
             ->addGroupBy('partLots')
             ->addGroupBy('category')

--- a/src/DataTables/ProjectBomEntriesDataTable.php
+++ b/src/DataTables/ProjectBomEntriesDataTable.php
@@ -185,7 +185,7 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
             ])
             ->add('storageLocations', TextColumn::class, [
                 'label' => 'part.table.storeLocations',
-                'orderField' => 'NATSORT(storageLocationOrder)',
+                'orderField' => 'NATSORT(MIN(storageLocations.name))',
                 'visible' => false,
                 'render' => function ($value, ProjectBOMEntry $context) {
                     if ($context->getPart() !== null) {
@@ -226,7 +226,6 @@ class ProjectBomEntriesDataTable implements DataTableTypeInterface
     {
         $builder->select('bom_entry')
             ->addSelect('part')
-            ->addSelect('(SELECT MIN(storageLocationSort.name) FROM ' . \App\Entity\Parts\PartLot::class . ' partLotSort LEFT JOIN partLotSort.storage_location storageLocationSort WHERE partLotSort.part = part) AS HIDDEN storageLocationOrder')
             ->from(ProjectBOMEntry::class, 'bom_entry')
             ->leftJoin('bom_entry.part', 'part')
             ->leftJoin('part.category', 'category')


### PR DESCRIPTION
This PR refactors ProjectBomEntriesDataTable to use the same robust two-step query strategy as PartsDataTable, resolving multiple query/pagination errors on the BOM page and restoring expected column behavior.

**What changed**

- Switched BOM datatable adapter to TwoStepORMAdapter.
- Added an ID-only filter_query for filtering/sorting/pagination.
- Added a detail_query for fetching full BOM entities and joins.
- Kept stable row ordering between filter/detail queries via FieldHelper::addOrderByFieldParam(...).
- Preserved storage location sorting support with aggregate ordering (NATSORT(MIN(_storelocations.name))).
- Added explicit sorting for Manufacturing Status (orderField => 'part.manufacturing_status').
- Aligned datatable entity usage with ProjectBOMEntry.

**Why**
The previous single-query fetch-join approach caused Doctrine/PgSQL failures such as:

- non-unique scalar/count query results,
- grouping errors,
- and Iterate with fetch join ... PartLot ... not allowed.
Using TwoStepORMAdapter avoids these fetch-join pagination pitfalls and keeps sorting/filtering functional.

**User-visible impact**
- BOM page loads reliably (including repeated loads/callbacks).
- Manufacturing Status column now displays values again.
- Manufacturing Status column is now sortable.

**Testing performed**

- Verified BOM datatable code path compiles (php -l)
- Manually validated query setup for normal BOM load
- tested storage location sorting
- tested manufacturing status display and sorting

Disclaimer: This description was written by Codex but manually edited and corrected.