### PR TITLE
Add SI-prefix-aware sorting column for parts tableFeature/si value sort

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -56,6 +56,7 @@ doctrine:
                 natsort: App\Doctrine\Functions\Natsort
                 array_position: App\Doctrine\Functions\ArrayPosition
                 ilike: App\Doctrine\Functions\ILike
+                si_value_sort: App\Doctrine\Functions\SiValueSort
 
 when@test:
     doctrine:

--- a/src/DataTables/PartsDataTable.php
+++ b/src/DataTables/PartsDataTable.php
@@ -119,8 +119,8 @@ final class PartsDataTable implements DataTableTypeInterface
                 'render' => fn($value, Part $context) => $this->partDataTableHelper->renderName($context),
                 'orderField' => 'NATSORT(part.name)'
             ])
-            ->add('si_name', TextColumn::class, [
-                'label' => $this->translator->trans('part.table.si_name'),
+            ->add('si_value', TextColumn::class, [
+                'label' => $this->translator->trans('part.table.si_value'),
                 'render' => function ($value, Part $context): string {
                     $siValue = SiValueSort::sqliteSiValue($context->getName());
                     if ($siValue !== null) {

--- a/src/DataTables/PartsDataTable.php
+++ b/src/DataTables/PartsDataTable.php
@@ -38,6 +38,7 @@ use App\DataTables\Filters\PartFilter;
 use App\DataTables\Filters\PartSearchFilter;
 use App\DataTables\Helpers\ColumnSortHelper;
 use App\DataTables\Helpers\PartDataTableHelper;
+use App\Doctrine\Functions\SiValueSort;
 use App\Doctrine\Helpers\FieldHelper;
 use App\Entity\Parts\ManufacturingStatus;
 use App\Entity\Parts\Part;
@@ -117,6 +118,17 @@ final class PartsDataTable implements DataTableTypeInterface
                 'label' => $this->translator->trans('part.table.name'),
                 'render' => fn($value, Part $context) => $this->partDataTableHelper->renderName($context),
                 'orderField' => 'NATSORT(part.name)'
+            ])
+            ->add('si_name', TextColumn::class, [
+                'label' => $this->translator->trans('part.table.si_name'),
+                'render' => function ($value, Part $context): string {
+                    $siValue = SiValueSort::sqliteSiValue($context->getName());
+                    if ($siValue !== null) {
+                        return htmlspecialchars(sprintf('%g', $siValue));
+                    }
+                    return '';
+                },
+                'orderField' => 'SI_VALUE_SORT(part.name)',
             ])
             ->add('id', TextColumn::class, [
                 'label' => $this->translator->trans('part.table.id'),
@@ -482,6 +494,19 @@ final class PartsDataTable implements DataTableTypeInterface
             //Do not group by many-to-* relations, as it would restrict the COUNT having clauses to be maximum 1
             //$builder->addGroupBy('_jobPart');
             //$builder->addGroupBy('_bulkImportJob');
+        }
+
+        //When sorting by SI value, add NATSORT as a secondary sort so that parts without
+        //an SI-prefixed value fall back to natural string ordering seamlessly.
+        $orderByParts = $builder->getDQLPart('orderBy');
+        foreach ($orderByParts as $orderBy) {
+            foreach ($orderBy->getParts() as $part) {
+                if (str_contains($part, 'SI_VALUE_SORT')) {
+                    $direction = str_contains($part, 'DESC') ? 'DESC' : 'ASC';
+                    $builder->addOrderBy('NATSORT(part.name)', $direction);
+                    break 2;
+                }
+            }
         }
 
         return $builder;

--- a/src/Doctrine/Functions/SiValueSort.php
+++ b/src/Doctrine/Functions/SiValueSort.php
@@ -1,0 +1,187 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2024 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Doctrine\Functions;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * Custom DQL function that extracts the first numeric value with an optional SI prefix
+ * from a string and returns the scaled numeric value for sorting.
+ *
+ * Usage: SI_VALUE_SORT(part.name)
+ *
+ * This enables sorting parts by their physical value. For example, capacitors
+ * named "100nF", "1uF", "10pF" will be sorted by actual value: 10pF < 100nF < 1uF.
+ *
+ * Supported SI prefixes: p (pico, 1e-12), n (nano, 1e-9), u/µ (micro, 1e-6),
+ * m (milli, 1e-3), k/K (kilo, 1e3), M (mega, 1e6), G (giga, 1e9), T (tera, 1e12).
+ *
+ * Only matches numbers at the very beginning of the string (ignoring leading whitespace).
+ * Names like "Crystal 20MHz" will NOT match since the number is not at the start.
+ * Names without a recognizable numeric+prefix pattern return NULL and sort last.
+ */
+class SiValueSort extends FunctionNode
+{
+    private ?Node $field = null;
+
+    /**
+     * SI prefix multipliers. Used by the SQLite PHP callback.
+     */
+    private const SI_MULTIPLIERS = [
+        'p' => 1e-12,
+        'n' => 1e-9,
+        'u' => 1e-6,
+        'µ' => 1e-6,
+        'm' => 1e-3,
+        'k' => 1e3,
+        'K' => 1e3,
+        'M' => 1e6,
+        'G' => 1e9,
+        'T' => 1e12,
+    ];
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->field = $parser->ArithmeticExpression();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        assert($this->field !== null, 'Field is not set');
+
+        $platform = $sqlWalker->getConnection()->getDatabasePlatform();
+        $fieldSql = $this->field->dispatch($sqlWalker);
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            return $this->getPostgreSQLSql($fieldSql);
+        }
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            return $this->getMySQLSql($fieldSql);
+        }
+
+        if ($platform instanceof SQLitePlatform) {
+            return "SI_VALUE({$fieldSql})";
+        }
+
+        // Fallback: return NULL (no SI sorting available)
+        return 'NULL';
+    }
+
+    /**
+     * PostgreSQL implementation using substring() with POSIX regex.
+     */
+    private function getPostgreSQLSql(string $field): string
+    {
+        // Extract the numeric part using POSIX regex, anchored at start (with optional leading whitespace)
+        $numericPart = "CAST(substring({$field} FROM '^\\s*(\\d+\\.?\\d*)\\s*[pnuµmkKMGT]?') AS DOUBLE PRECISION)";
+
+        // Extract the SI prefix character
+        $prefixPart = "substring({$field} FROM '^\\s*\\d+\\.?\\d*\\s*([pnuµmkKMGT])')";
+
+        return $this->buildCaseExpression($numericPart, $prefixPart);
+    }
+
+    /**
+     * MySQL/MariaDB implementation using REGEXP_SUBSTR.
+     */
+    private function getMySQLSql(string $field): string
+    {
+        // Extract the numeric part, anchored at start (with optional leading whitespace)
+        $numericPart = "CAST(REGEXP_SUBSTR({$field}, '^[[:space:]]*[0-9]+\\.?[0-9]*') AS DECIMAL(30,15))";
+
+        // Extract the prefix: get the full number+prefix match anchored at start, then take the last char
+        $fullMatch = "REGEXP_SUBSTR({$field}, '^[[:space:]]*[0-9]+\\.?[0-9]*[[:space:]]*[pnuµmkKMGT]')";
+        $prefixPart = "RIGHT({$fullMatch}, 1)";
+
+        return $this->buildCaseExpression($numericPart, $prefixPart);
+    }
+
+    /**
+     * Build a CASE expression that maps an SI prefix character to a multiplier
+     * and multiplies it with the numeric value.
+     *
+     * @param string $numericExpr SQL expression that evaluates to the numeric part
+     * @param string $prefixExpr SQL expression that evaluates to the SI prefix character
+     * @return string SQL CASE expression
+     */
+    private function buildCaseExpression(string $numericExpr, string $prefixExpr): string
+    {
+        return "(CASE" .
+            " WHEN {$numericExpr} IS NULL THEN NULL" .
+            " WHEN {$prefixExpr} = 'p' THEN {$numericExpr} * 1e-12" .
+            " WHEN {$prefixExpr} = 'n' THEN {$numericExpr} * 1e-9" .
+            " WHEN {$prefixExpr} = 'u' THEN {$numericExpr} * 1e-6" .
+            " WHEN {$prefixExpr} = 'µ' THEN {$numericExpr} * 1e-6" .
+            " WHEN {$prefixExpr} = 'm' THEN {$numericExpr} * 1e-3" .
+            " WHEN {$prefixExpr} = 'k' THEN {$numericExpr} * 1e3" .
+            " WHEN {$prefixExpr} = 'K' THEN {$numericExpr} * 1e3" .
+            " WHEN {$prefixExpr} = 'M' THEN {$numericExpr} * 1e6" .
+            " WHEN {$prefixExpr} = 'G' THEN {$numericExpr} * 1e9" .
+            " WHEN {$prefixExpr} = 'T' THEN {$numericExpr} * 1e12" .
+            " ELSE {$numericExpr} * 1" .
+            " END)";
+    }
+
+    /**
+     * PHP callback for SQLite's SI_VALUE function.
+     * Extracts the first numeric value with an optional SI prefix and returns the scaled value.
+     *
+     * @param string|null $value The input string
+     * @return float|null The scaled numeric value, or null if no number found
+     */
+    public static function sqliteSiValue(?string $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        // Match a number at the very start (allowing leading whitespace), optionally followed by an SI prefix
+        if (!preg_match('/^\s*(\d+\.?\d*)\s*([pnuµmkKMGT])?/u', $value, $matches)) {
+            return null;
+        }
+
+        $number = (float) $matches[1];
+        $prefix = $matches[2] ?? '';
+
+        if ($prefix === '') {
+            return $number;
+        }
+
+        $multiplier = self::SI_MULTIPLIERS[$prefix] ?? 1.0;
+
+        return $number * $multiplier;
+    }
+}

--- a/src/Doctrine/Functions/SiValueSort.php
+++ b/src/Doctrine/Functions/SiValueSort.php
@@ -82,7 +82,10 @@ class SiValueSort extends FunctionNode
         assert($this->field !== null, 'Field is not set');
 
         $platform = $sqlWalker->getConnection()->getDatabasePlatform();
-        $fieldSql = $this->field->dispatch($sqlWalker);
+        $rawField = $this->field->dispatch($sqlWalker);
+
+        // Normalize comma decimal separator to dot for SQL platforms (European locale support)
+        $fieldSql = "REPLACE({$rawField}, ',', '.')";
 
         if ($platform instanceof PostgreSQLPlatform) {
             return $this->getPostgreSQLSql($fieldSql);
@@ -91,6 +94,9 @@ class SiValueSort extends FunctionNode
         if ($platform instanceof AbstractMySQLPlatform) {
             return $this->getMySQLSql($fieldSql);
         }
+
+        // SQLite: comma normalization is handled in the PHP callback
+        $fieldSql = $rawField;
 
         if ($platform instanceof SQLitePlatform) {
             return "SI_VALUE({$fieldSql})";
@@ -167,6 +173,9 @@ class SiValueSort extends FunctionNode
         if ($value === null) {
             return null;
         }
+
+        // Normalize comma decimal separator to dot (European locale support)
+        $value = str_replace(',', '.', $value);
 
         // Match a number at the very start (allowing leading whitespace), optionally followed by an SI prefix
         if (!preg_match('/^\s*(\d+\.?\d*)\s*([pnuµmkKMGT])?/u', $value, $matches)) {

--- a/src/Doctrine/Middleware/SQLiteRegexExtensionMiddlewareDriver.php
+++ b/src/Doctrine/Middleware/SQLiteRegexExtensionMiddlewareDriver.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\Doctrine\Middleware;
 
+use App\Doctrine\Functions\SiValueSort;
 use App\Exceptions\InvalidRegexException;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
@@ -51,6 +52,9 @@ class SQLiteRegexExtensionMiddlewareDriver extends AbstractDriverMiddleware
 
                 //Create a new collation for natural sorting
                 $native_connection->sqliteCreateCollation('NATURAL_CMP', strnatcmp(...));
+
+                //Create a function for SI prefix value sorting
+                $native_connection->sqliteCreateFunction('SI_VALUE', SiValueSort::sqliteSiValue(...), 1, \PDO::SQLITE_DETERMINISTIC);
             }
         }
 

--- a/src/Settings/BehaviorSettings/PartTableColumns.php
+++ b/src/Settings/BehaviorSettings/PartTableColumns.php
@@ -52,6 +52,8 @@ enum PartTableColumns : string implements TranslatableInterface
     case TAGS = "tags";
     case ATTACHMENTS = "attachments";
 
+    case SI_NAME = "si_name";
+
     case EDA_REFERENCE = "eda_reference";
 
     case EDA_VALUE = "eda_value";
@@ -67,6 +69,7 @@ enum PartTableColumns : string implements TranslatableInterface
             self::NEEDS_REVIEW => 'part.table.needsReview',
             self::MANUFACTURING_STATUS => 'part.table.manufacturingStatus',
             self::MPN => 'part.table.mpn',
+            self::SI_NAME => 'part.table.si_name',
             default => 'part.table.' . $this->value,
         };
 

--- a/src/Settings/BehaviorSettings/PartTableColumns.php
+++ b/src/Settings/BehaviorSettings/PartTableColumns.php
@@ -52,7 +52,7 @@ enum PartTableColumns : string implements TranslatableInterface
     case TAGS = "tags";
     case ATTACHMENTS = "attachments";
 
-    case SI_NAME = "si_name";
+    case SI_VALUE = "si_value";
 
     case EDA_REFERENCE = "eda_reference";
 
@@ -69,7 +69,6 @@ enum PartTableColumns : string implements TranslatableInterface
             self::NEEDS_REVIEW => 'part.table.needsReview',
             self::MANUFACTURING_STATUS => 'part.table.manufacturingStatus',
             self::MPN => 'part.table.mpn',
-            self::SI_NAME => 'part.table.si_name',
             default => 'part.table.' . $this->value,
         };
 

--- a/tests/Doctrine/Functions/SiValueSortTest.php
+++ b/tests/Doctrine/Functions/SiValueSortTest.php
@@ -37,7 +37,7 @@ final class SiValueSortTest extends AbstractDoctrineFunctionTestCase
         $sql = $function->getSql($this->createSqlWalker(new PostgreSQLPlatform()));
 
         $this->assertStringContainsString('CASE', $sql);
-        $this->assertStringContainsString('substring(part_name', $sql);
+        $this->assertStringContainsString("REPLACE(part_name, ',', '.')", $sql);
         $this->assertStringContainsString('1e-12', $sql);
         $this->assertStringContainsString('1e-9', $sql);
         $this->assertStringContainsString('1e-6', $sql);
@@ -56,7 +56,7 @@ final class SiValueSortTest extends AbstractDoctrineFunctionTestCase
         $sql = $function->getSql($this->createSqlWalker(new MySQLPlatform()));
 
         $this->assertStringContainsString('CASE', $sql);
-        $this->assertStringContainsString('REGEXP_SUBSTR(part_name', $sql);
+        $this->assertStringContainsString("REPLACE(part_name, ',', '.')", $sql);
         $this->assertStringContainsString('1e-12', $sql);
         $this->assertStringContainsString('1e6', $sql);
     }
@@ -106,10 +106,15 @@ final class SiValueSortTest extends AbstractDoctrineFunctionTestCase
         yield 'plain_integer' => ['100', 100.0];
         yield 'plain_decimal' => ['4.7', 4.7];
 
-        // Decimal values with prefix
+        // Decimal values with prefix (dot separator)
         yield 'decimal_nano' => ['4.7nF', 4.7e-9];
         yield 'decimal_micro' => ['0.1uF', 0.1e-6];
         yield 'decimal_kilo' => ['2.2k', 2.2e3];
+
+        // Comma decimal separator (European locale)
+        yield 'comma_kilo' => ['4,7k', 4.7e3];
+        yield 'comma_micro' => ['2,2uF', 2.2e-6];
+        yield 'comma_kilo_space' => ['1,2 kΩ', 1.2e3];
 
         // Number NOT at the start — should return NULL
         yield 'prefixed_name' => ['CAP-100nF', null];

--- a/tests/Doctrine/Functions/SiValueSortTest.php
+++ b/tests/Doctrine/Functions/SiValueSortTest.php
@@ -1,0 +1,188 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Doctrine\Functions;
+
+use App\Doctrine\Functions\SiValueSort;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+
+final class SiValueSortTest extends AbstractDoctrineFunctionTestCase
+{
+    public function testPostgreSQLGeneratesCaseExpression(): void
+    {
+        $function = new SiValueSort('SI_VALUE_SORT');
+        $this->setObjectProperty($function, 'field', $this->createNode('part_name'));
+
+        $sql = $function->getSql($this->createSqlWalker(new PostgreSQLPlatform()));
+
+        $this->assertStringContainsString('CASE', $sql);
+        $this->assertStringContainsString('substring(part_name', $sql);
+        $this->assertStringContainsString('1e-12', $sql);
+        $this->assertStringContainsString('1e-9', $sql);
+        $this->assertStringContainsString('1e-6', $sql);
+        $this->assertStringContainsString('1e-3', $sql);
+        $this->assertStringContainsString('1e3', $sql);
+        $this->assertStringContainsString('1e6', $sql);
+        $this->assertStringContainsString('1e9', $sql);
+        $this->assertStringContainsString('1e12', $sql);
+    }
+
+    public function testMySQLGeneratesCaseExpression(): void
+    {
+        $function = new SiValueSort('SI_VALUE_SORT');
+        $this->setObjectProperty($function, 'field', $this->createNode('part_name'));
+
+        $sql = $function->getSql($this->createSqlWalker(new MySQLPlatform()));
+
+        $this->assertStringContainsString('CASE', $sql);
+        $this->assertStringContainsString('REGEXP_SUBSTR(part_name', $sql);
+        $this->assertStringContainsString('1e-12', $sql);
+        $this->assertStringContainsString('1e6', $sql);
+    }
+
+    public function testSQLiteUsesSiValueFunction(): void
+    {
+        $function = new SiValueSort('SI_VALUE_SORT');
+        $this->setObjectProperty($function, 'field', $this->createNode('part_name'));
+
+        $sql = $function->getSql($this->createSqlWalker(new SQLitePlatform()));
+
+        $this->assertSame('SI_VALUE(part_name)', $sql);
+    }
+
+    /**
+     * @dataProvider sqliteSiValueProvider
+     */
+    public function testSqliteSiValue(?string $input, ?float $expected): void
+    {
+        $result = SiValueSort::sqliteSiValue($input);
+
+        if ($expected === null) {
+            $this->assertNull($result);
+        } else {
+            $this->assertEqualsWithDelta($expected, $result, $expected * 1e-9);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{?string, ?float}>
+     */
+    public static function sqliteSiValueProvider(): iterable
+    {
+        // Basic SI prefix values
+        yield 'pico' => ['10pF', 10e-12];
+        yield 'nano' => ['100nF', 100e-9];
+        yield 'micro_u' => ['1uF', 1e-6];
+        yield 'micro_µ' => ['1µF', 1e-6];
+        yield 'milli' => ['4.7mH', 4.7e-3];
+        yield 'kilo_lower' => ['4.7k', 4.7e3];
+        yield 'kilo_upper' => ['4.7K', 4.7e3];
+        yield 'mega' => ['1M', 1e6];
+        yield 'giga' => ['2.2G', 2.2e9];
+        yield 'tera' => ['1T', 1e12];
+
+        // No prefix (plain number)
+        yield 'plain_integer' => ['100', 100.0];
+        yield 'plain_decimal' => ['4.7', 4.7];
+
+        // Decimal values with prefix
+        yield 'decimal_nano' => ['4.7nF', 4.7e-9];
+        yield 'decimal_micro' => ['0.1uF', 0.1e-6];
+        yield 'decimal_kilo' => ['2.2k', 2.2e3];
+
+        // Number NOT at the start — should return NULL
+        yield 'prefixed_name' => ['CAP-100nF', null];
+        yield 'name_with_number' => ['R 4.7k 1%', null];
+        yield 'crystal' => ['Crystal 20MHz', null];
+
+        // Number at start with trailing text
+        yield 'number_with_suffix' => ['10nF 25V', 10e-9];
+
+        // Space between number and prefix
+        yield 'space_before_prefix' => ['100 nF', 100e-9];
+
+        // Leading whitespace before number
+        yield 'leading_whitespace' => ['  10uF', 10e-6];
+
+        // No number at all
+        yield 'no_number' => ['Connector', null];
+        yield 'text_only' => ['LED red', null];
+
+        // Null input
+        yield 'null' => [null, null];
+
+        // Empty string
+        yield 'empty' => ['', null];
+    }
+
+    /**
+     * Test that the sort order is correct by comparing sqliteSiValue results.
+     */
+    public function testSortOrder(): void
+    {
+        $parts = ['1uF', '100nF', '10pF', '10uF', '0.1mF', '1F', '10kF', '1MF'];
+        $expected = ['10pF', '100nF', '1uF', '10uF', '0.1mF', '1F', '10kF', '1MF'];
+
+        // Sort using sqliteSiValue
+        usort($parts, static function (string $a, string $b): int {
+            $va = SiValueSort::sqliteSiValue($a);
+            $vb = SiValueSort::sqliteSiValue($b);
+            return $va <=> $vb;
+        });
+
+        $this->assertSame($expected, $parts);
+    }
+
+    /**
+     * Test that NULL values sort last (after all numeric values).
+     */
+    public function testNullSortsLast(): void
+    {
+        $parts = ['Connector', '100nF', 'LED red', '10pF'];
+
+        usort($parts, static function (string $a, string $b): int {
+            $va = SiValueSort::sqliteSiValue($a);
+            $vb = SiValueSort::sqliteSiValue($b);
+
+            // NULL sorts last
+            if ($va === null && $vb === null) {
+                return 0;
+            }
+            if ($va === null) {
+                return 1;
+            }
+            if ($vb === null) {
+                return -1;
+            }
+
+            return $va <=> $vb;
+        });
+
+        $this->assertSame('10pF', $parts[0]);
+        $this->assertSame('100nF', $parts[1]);
+        // Last two should be the non-numeric names
+        $this->assertContains('Connector', array_slice($parts, 2));
+        $this->assertContains('LED red', array_slice($parts, 2));
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2780,10 +2780,10 @@ If you have done this incorrectly or if a computer is no longer trusted, you can
         <target>Name</target>
       </segment>
     </unit>
-    <unit id="sIvAlUe" name="part.table.si_name">
+    <unit id="sIvAlUe" name="part.table.si_value">
       <segment state="translated">
-        <source>part.table.si_name</source>
-        <target>Name (SI)</target>
+        <source>part.table.si_value</source>
+        <target>SI Value</target>
       </segment>
     </unit>
     <unit id="rW_SFJE" name="part.table.id">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2780,6 +2780,12 @@ If you have done this incorrectly or if a computer is no longer trusted, you can
         <target>Name</target>
       </segment>
     </unit>
+    <unit id="sIvAlUe" name="part.table.si_name">
+      <segment state="translated">
+        <source>part.table.si_name</source>
+        <target>Name (SI)</target>
+      </segment>
+    </unit>
     <unit id="rW_SFJE" name="part.table.id">
       <segment state="translated">
         <source>part.table.id</source>


### PR DESCRIPTION
## Summary

  - Adds an optional **"SI Value"** column to the parts table that parses numeric values with SI prefixes (p, n, u/µ, m, k/K, M, G, T) from part names and sorts by the resulting physical value
  - Useful for electronic components where alphabetical sorting produces wrong results — e.g. `100nF`, `10pF`, `1uF` sort as `10pF < 100nF < 1uF`
  - The column displays the parsed float value, or an empty cell for non-matching names
  - Only matches numbers at the start of the name — part numbers like "MCP2515" or "Crystal 20MHz" are not affected
  - Supports both dot and comma decimal separators (European locale)
  - Falls back to NATSORT for parts without SI values, so they sort alphabetically rather than arbitrarily
  - Opt-in: not in default columns, users enable it via the column visibility button

  ### Implementation

  - New `SiValueSort` DQL function with platform-specific SQL for PostgreSQL (POSIX regex), MySQL/MariaDB (REGEXP_SUBSTR), and SQLite (PHP callback via the existing middleware)
  - 33 unit tests covering all platforms, SI prefixes, edge cases, and sort order verification

  ## Test plan

  - [x] Unit tests pass (33 tests, all platforms)
  - [x] PHPStan level 2 passes
  - [x] Tested against real parts database with SQLite