### PR TITLE
Fix sort order after column reorder on page reload

### DIFF
--- a/assets/controllers/elements/datatables/datatables_controller.js
+++ b/assets/controllers/elements/datatables/datatables_controller.js
@@ -113,8 +113,16 @@ export default class extends Controller {
                     return null;
                 }
 
+                //The saved order index is visual (post-reorder). If colReorder state
+                //exists, map it back to the original column index so the server sorts
+                //the correct column. colReorder[visualIndex] == originalIndex.
+                let columnIndex = order[0];
+                if (saved_state.colReorder) {
+                    columnIndex = saved_state.colReorder[columnIndex];
+                }
+
                 return {
-                    column: order[0],
+                    column: columnIndex,
                     dir: order[1]
                 }
             });


### PR DESCRIPTION
## Summary

- Fixes incorrect sort order when columns have been reordered via colReorder drag-and-drop and the page is reloaded
- The saved sort state uses visual (post-reorder) column indices, but `initial_order` was sending them to the server as-is — the server interpreted them as original indices, sorting the wrong column
- Uses the saved `colReorder` mapping to translate visual indices back to original indices before sending `initial_order` in the `_init` request

## Steps to reproduce

1. Open any DataTables view (e.g. parts list)
2. Drag a column to reorder it
3. Click a column header to sort
4. Reload the page
5. **Before fix:** wrong column is sorted. **After fix:** correct column is sorted.